### PR TITLE
update: Add buildermethods Agent OS GitHub URL to prompt for clarity

### DIFF
--- a/.agent-os/specs/2025-07-29-agent-os-integration/spec.md
+++ b/.agent-os/specs/2025-07-29-agent-os-integration/spec.md
@@ -8,7 +8,7 @@
 
 **Prompt for Future Reuse:**
 ```
-Set up Agent OS for this repository with comprehensive team collaboration features. Execute the following implementation with logical task dependency ordering:
+Set up buildermethods Agent OS (https://github.com/buildermethods/agent-os) for this repository with comprehensive team collaboration features. Execute the following implementation with logical task dependency ordering:
 
 TASK DEPENDENCY ORDERING STANDARD:
 - All implementation tasks must follow logical dependency ordering where prior tasks are always applicable (if logical) to subsequent tasks


### PR DESCRIPTION
## Summary

Added the official buildermethods Agent OS GitHub URL to the executive summary prompt to provide teams with a clear reference to the official source repository.

## Changes Made

- ✅ Added specific Agent OS repository URL: `https://github.com/buildermethods/agent-os`
- ✅ Enhanced prompt completeness by including official source location
- ✅ Provides clear reference for teams implementing the specification

## Impact

### 🎯 **For Implementation Teams**
- Teams now have direct access to the official Agent OS repository
- Clear source of truth for Agent OS documentation and installation
- Eliminates ambiguity about which Agent OS framework to use

### 📋 **For Prompt Completeness**
- Fulfills the self-contained prompt requirement by including the official source
- Teams can access the repository directly without searching
- Maintains the established completeness standard for future specs

## Before/After

**Before:**
```
Set up Agent OS for this repository with comprehensive team collaboration features...
```

**After:**
```
Set up buildermethods Agent OS (https://github.com/buildermethods/agent-os) for this repository with comprehensive team collaboration features...
```

## Test Plan

- [x] URL is valid and points to the official buildermethods Agent OS repository
- [x] Prompt remains self-contained and complete
- [x] Teams can now directly access the source repository for implementation guidance

🤖 Generated with [Claude Code](https://claude.ai/code)