### PR TITLE
chore(gitignore): exclude .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ desktop.ini
 __MACOSX/
 specs/
 !src/**/specs/
+
+# Agent worktrees (local-only, must not be tracked as gitlinks)
+.claude/worktrees/


### PR DESCRIPTION
Prevents Claude-agent worktrees from being tracked as submodule gitlinks.

Ref: vamseeachanta/workspace-hub#2326