### PR TITLE
fix(packaging): ship base_configs/** as package data (#88); v0.1.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,10 @@ jobs:
       - name: Run repo-structure contract gate
         run: uv run python scripts/maintenance/verify_repo_structure.py
 
+      - name: Verify base_configs ship in the wheel (assetutilities#88 guard)
+        run: |
+          uv build --wheel --out-dir dist_check
+          uv run python scripts/maintenance/check_wheel_package_data.py dist_check
+
       - name: Run tests
         run: uv run python -m pytest tests -q --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assetutilities"
-version = "0.1.0"
+version = "0.1.1"
 description = "Standardized project configuration for assetutilities"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -114,6 +114,12 @@ assetutils-propagate = "assetutilities.devtools.cli:main"
 where = ["src"]
 include = ["assetutilities*"]
 exclude = ["tests*", "docs*"]
+
+# Ship the per-basename engine configs loaded via pkgutil.get_data() at runtime.
+# Without this they are dropped from the wheel (base_configs/ is not a Python package),
+# breaking every workflow when installed from a wheel. See assetutilities#88.
+[tool.setuptools.package-data]
+assetutilities = ["base_configs/**/*.yml", "base_configs/**/*.yaml", "base_configs/**/*.csv"]
 
 [tool.black]
 line-length = 88

--- a/scripts/maintenance/check_wheel_package_data.py
+++ b/scripts/maintenance/check_wheel_package_data.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Guard for assetutilities#88: ensure base_configs/**/*.yml ship in the built wheel.
+
+The per-basename engine configs (loaded at runtime via ``pkgutil.get_data`` in
+common/ApplicationManager.py) live under ``src/assetutilities/base_configs/``, which is
+NOT a Python package. ``setuptools.packages.find`` therefore ignores them, and they vanish
+from the wheel unless declared as package-data. When that happens every workflow breaks the
+moment assetutilities is installed from a wheel (it only "works" from a source checkout).
+
+This guard builds/inspects the wheel and fails loudly if the config tree is absent, so the
+regression cannot silently reappear.
+
+Usage: python scripts/maintenance/check_wheel_package_data.py <dist_dir>
+"""
+import sys
+import zipfile
+from pathlib import Path
+
+
+def main(dist_dir: str) -> int:
+    wheels = sorted(Path(dist_dir).glob("*.whl"))
+    if not wheels:
+        print(f"ERROR: no wheel found in {dist_dir!r}", file=sys.stderr)
+        return 1
+    wheel = wheels[-1]
+    with zipfile.ZipFile(wheel) as z:
+        ymls = [
+            n
+            for n in z.namelist()
+            if n.startswith("assetutilities/base_configs/") and n.endswith(".yml")
+        ]
+    if not ymls:
+        print(
+            f"ERROR: {wheel.name} ships 0 base_configs/**/*.yml — package data is missing. "
+            f"Check [tool.setuptools.package-data] in pyproject.toml (assetutilities#88).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {wheel.name} ships {len(ymls)} base_configs/**/*.yml files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "dist"))

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "assetutilities"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What & why

`base_configs/` is not a Python package (no `__init__.py`), so `setuptools.packages.find` never collected it and there was no `package-data` declaration. The 26 `base_configs/**/*.yml` engine configs — loaded at runtime via `pkgutil.get_data()` in `common/ApplicationManager.py:128` — were **dropped from the wheel**, so they resolve from a source/editable checkout but raise `FileNotFoundError` when assetutilities is installed from a wheel.

**Scope is wider than the issue title:** that loader is the **per-basename engine config loader for all 17 routed basenames**, not just the visualization templates — so from a wheel install *every* workflow that resolves a base config fails. This is the hard prerequisite for the assetutilities workflow registry (workspace-hub#3063, epic workspace-hub#3050).

## Change
- `pyproject.toml`: add `[tool.setuptools.package-data]` → `base_configs/**/*.{yml,yaml,csv}`
- bump `0.1.0 → 0.1.1` (the fix is inert until a release is published + pinned downstream)
- CI guard: build the wheel and assert `base_configs/**/*.yml` ship (new `scripts/maintenance/check_wheel_package_data.py`, wired into `tests.yml`) so this can't silently regress

## Verification (local)
| | base_configs yml in wheel |
|---|---|
| before fix | **0** |
| after fix (v0.1.1) | **26** |

Existing CI gates (source-hygiene, repo-structure) still pass locally.

## Follow-through (not in this PR)
- [ ] After merge + release: downstream **digitalmodel** can flip plot generation default back **on** (PR #710 gated it off as a workaround).
- [ ] Pin `assetutilities>=0.1.1` in consumers.

Closes #88.