### PR TITLE
Scope repo-local agent memory (epic #3084)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,10 @@
+# assetutilities — repo-scoped memory
+
+Session context for THIS repo only (epic #3084 context-flow backbone).
+Keep entries scoped to assetutilities; cross-repo facts stay in workspace-hub memory.
+
+## Project
+- (repo mission summary — see config/mission/mission-map.yaml in workspace-hub)
+
+## Feedback
+- (none yet — repo-scoped feedback accrues here instead of the workspace-hub blob)

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,7 @@ specs/
 
 # Agent worktrees (local-only, must not be tracked as gitlinks)
 .claude/worktrees/
+
+# epic #3084: keep repo-scoped agent memory tracked despite blanket memory/ rule
+!.claude/memory/
+!.claude/memory/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,4 @@ Plans: `.planning/` (long-duration: `docs/plans/`) | Specs: `specs/`
 
 ## Repo Overrides
 Add repo-specific rules below without weakening required gates.
+> Memory: read THIS repo's `.claude/memory/` first; consult workspace-hub memory only for cross-repo concerns


### PR DESCRIPTION
Part of workspace-hub epic #3078 / #3084. Adds .claude/memory/ + CLAUDE.md precedence line for clean per-repo agent context. Generated by scripts/memory/scope-repo-memory.sh.