### PR TITLE
fix(mypy): exclude hyphenated module dirs so mypy runs (workspace-hub#3148)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+# Hyphenated module dirs are not valid Python package names — mypy aborts (exit 2)
+# on them before type-checking. Exclude so mypy runs (workspace-hub#3148).
+# Follow-up: rename these dirs to valid package names.
+exclude = '(^|/)(web-contextualization|agent-os)(/|$)'
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
web-contextualization and agent-os are not valid Python package names → mypy aborted (exit 2) before type-checking ('FAIL (0 errors)'). Add [tool.mypy] exclude so mypy runs (exit 1, 1148 errors) and workspace-hub's check-all mypy ratchet can baseline this repo. Follow-up: rename the dirs to valid package names.