### PR TITLE
feat(pages): deploy existing mkdocs API docs to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build docs
+        run: uv run --group docs mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ specs/
 # epic #3084: keep repo-scoped agent memory tracked despite blanket memory/ rule
 !.claude/memory/
 !.claude/memory/**
+
+# MkDocs build output (regenerated in CI)
+site/


### PR DESCRIPTION
Implements the Pages demo for this repo (#96), part of ecosystem epic vamseeachanta/workspace-hub#3223.

## What's here
Adds `.github/workflows/pages.yml` that builds the **existing** mkdocs site and deploys it via the official Pages actions. Uses the identical build command as the current `docs.yml` CI (`uv run --group docs mkdocs build --strict`), so if docs CI passes, this deploys.

The mkdocs `docs_dir` is `docs/api` (auto-generated mkdocstrings API reference), so the published site is the library's API documentation — **no client reports or generated artifacts are included** (the `docs/sub_python/digital_reports/` FDAS deliverables live outside the mkdocs scope and are not touched). `site/` is gitignored.

This is the minimal real increment: the repo already had mkdocs configured but CI only *built* it (no deploy) — this adds the last mile. A curated visualization/report gallery can follow as a separate enhancement.

## One-time after merge
Settings → Pages → Source = GitHub Actions.
