### PR TITLE
fix: make result-folder mkdir and pytest detection xdist-safe (#100, #101)

### DIFF
--- a/src/assetutilities/common/ApplicationManager.py
+++ b/src/assetutilities/common/ApplicationManager.py
@@ -138,9 +138,23 @@ class ConfigureApplicationInputs:
         return cfg
 
     def get_custom_file(self, run_dict=None, inputfile=None):
-        # Detect if running under pytest
-        is_pytest = any("pytest" in arg or "_pytest" in arg for arg in sys.argv[0:2])
-        
+        # Detect if running under pytest.
+        #
+        # The argv-based check only works in the main pytest process. Under
+        # pytest-xdist each test runs in a separate worker subprocess whose
+        # sys.argv is ['-c'] (execnet bootstrap), so the argv check returns
+        # False there and the engine would silently skip merging the per-test
+        # input YAML -- flipping file_management.flag and raising
+        # KeyError: 'input_directory' (issue #101). PYTEST_CURRENT_TEST is set
+        # by pytest in every test-executing process, including xdist workers,
+        # so it is the robust signal; "pytest" in sys.modules is an additional
+        # fallback. The original argv check is kept for backward compatibility.
+        is_pytest = (
+            "PYTEST_CURRENT_TEST" in os.environ
+            or "pytest" in sys.modules
+            or any("pytest" in arg or "_pytest" in arg for arg in sys.argv[0:2])
+        )
+
         try:
             # During pytest, use the inputfile parameter if provided
             if is_pytest and inputfile is not None:
@@ -306,12 +320,10 @@ class ConfigureApplicationInputs:
             os.makedirs(result_folder, exist_ok=True)
 
         result_data_folder = os.path.join(result_folder, "Data")
-        if not os.path.exists(result_data_folder):
-            os.mkdir(result_data_folder)
+        os.makedirs(result_data_folder, exist_ok=True)
 
         result_plot_folder = os.path.join(result_folder, "Plot")
-        if not os.path.exists(result_plot_folder):
-            os.mkdir(result_plot_folder)
+        os.makedirs(result_plot_folder, exist_ok=True)
 
         result_folder_dict = {
             "result_folder": result_folder,


### PR DESCRIPTION
Fixes the two real concurrency bugs the domain-matrix CI surfaced. PR #98 (the matrix) is already merged; this is the follow-up fix so the \`data_exploration\` and \`yml_utilities\` domain shards go green under \`pytest -n auto\`.

## #100 — TOCTOU mkdir race (data_exploration)
\`ApplicationManager.configure_result_folder\` created the \`Data/\` and \`Plot/\` subfolders with check-then-act \`os.mkdir\`. When concurrent \`engine()\` runs target the same \`results/\` dir under xdist, both pass the \`exists\` check and one \`os.mkdir\` raises \`FileExistsError\`. Switched both to \`os.makedirs(..., exist_ok=True)\`, matching the race-safe form already used a few lines above.

## #101 — pytest detection fails in xdist workers (yml_utilities)
Root cause (verified by instrumentation, not the issue's guessed cwd/shared-state theory): \`get_custom_file\` detected pytest **only** via \`sys.argv[0:2]\`. In execnet-spawned xdist worker subprocesses \`sys.argv == ['-c']\`, so detection returned \`False\` and the worker skipped merging the per-test input YAML. That left the packaged default config (\`base_configs/modules/yaml_utilities/yaml_utilities.yml\`, which has \`file_management.flag: True\` and **no** \`input_directory\` key) in effect, so the engine ran \`FileManagement.get_files_in_directory\` and hit \`KeyError: 'input_directory'\` at \`file_management.py:150\`.

Confirmed in an xdist worker: \`sys.argv[0:2] == ['-c']\` (argv check False) but \`PYTEST_CURRENT_TEST\` is set and \`'pytest' in sys.modules\` is True. Detection now honors \`PYTEST_CURRENT_TEST\` (set by pytest in every test-executing process, including xdist workers) and \`'pytest' in sys.modules\`, keeping the original argv check for back-compat. This makes the merged config identical in sequential and xdist runs.

## Verification (local, this branch off main)
- \`pytest tests/modules/data_exploration -n auto\` -> 7 passed
- \`pytest tests/modules/yml_utilities -n auto\` -> 10 passed
- \`pytest tests/modules/yml_utilities -n 0\` -> 10 passed (no sequential regression)
- combined \`-n auto\` -> 17 passed

## Expected CI result
\`Domain modules-data_exploration\` and \`Domain modules-yml_utilities\` shards turn green.

Closes #100
Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)