### PR TITLE
ci: adopt workspace-hub reusable domain-matrix workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,140 +45,24 @@ jobs:
           uv build --wheel --out-dir dist_check
           uv run python scripts/maintenance/check_wheel_package_data.py dist_check
 
-  # --------------------------------------------------- domain discovery ------
-  # Modular per-domain test gate (ported from worldenergydata#531): a change
+  # --------------------------------------------------- domain test matrix ----
+  # Modular per-domain test gate. The discover -> test-domain (matrix) ->
+  # aggregate scaffolding now lives ONCE in workspace-hub's reusable
+  # domain-matrix.yml (worldenergydata#526 / #530, P4); this caller just wires
+  # it up. assetutilities keeps its OWN repo-specific selector
+  # (scripts/ci/select_test_targets.py) + quarantine list
+  # (scripts/ci/quarantine.txt) — the reusable workflow runs them. A change
   # fans out into one CI job per touched domain (+ the always-on cross-cutting
-  # core), so each domain passes/fails in isolation (a red domain no longer
-  # blocks green siblings) and they run in parallel. Targets come from
-  # scripts/ci/select_test_targets.py --emit-matrix — the single source of
-  # truth (a module is mapped iff tests/modules/<module>/ exists; new modules
-  # auto-map, guarded by tests/ci/test_select_test_targets.py). On core-path
-  # changes the matrix fans out to EVERY domain. The aggregate "Run Tests" job
-  # is the single required status check (name preserved for branch protection).
-  discover:
-    name: Discover domains
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.sel.outputs.matrix }}
-      scope: ${{ steps.sel.outputs.scope }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # need the base commit to diff changed files
-
-      - name: Select domain matrix
-        id: sel
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          # Stdlib only — no uv sync needed (keeps discovery fast).
-          if [ -n "$BASE_SHA" ]; then
-            git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
-          else
-            # push / dispatch: diff against the previous commit (fall back to a
-            # core path so a first/forced commit fans out to the full tree).
-            git diff --name-only HEAD~1...HEAD > changed-files.txt 2>/dev/null \
-              || echo "uv.lock" > changed-files.txt
-          fi
-          echo "Changed files:"; cat changed-files.txt
-          python3 scripts/ci/select_test_targets.py \
-            --emit-matrix --files-from changed-files.txt >> "$GITHUB_OUTPUT"
-          echo "--- matrix ---"; grep '^matrix=' "$GITHUB_OUTPUT" || true
-
-  test-domain:
-    name: Domain ${{ matrix.name }}
-    needs: discover
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false  # one red domain must not cancel the others
-      max-parallel: 10  # bound the fan-out (core changes can be ~28 domains)
-      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install dependencies
-        run: uv sync --group test
-
-      - name: Run domain tests (${{ matrix.name }})
-        env:
-          TARGETS: ${{ matrix.targets }}
-          MODE: ${{ matrix.mode }}
-          SHARD: ${{ matrix.name }}
-        run: |
-          # Build --deselect args for quarantined tests (known-broken on main,
-          # tracked by issues; see scripts/ci/quarantine.txt). They still RUN
-          # but do not block, at test granularity (never whole shards).
-          DESELECT=()
-          if [ -f scripts/ci/quarantine.txt ]; then
-            while IFS= read -r raw; do
-              line="${raw%%#*}"
-              line="$(echo "$line" | xargs || true)"
-              [ -z "$line" ] && continue
-              DESELECT+=(--deselect "$line")
-            done < scripts/ci/quarantine.txt
-          fi
-          [ "${#DESELECT[@]}" -gt 0 ] && echo "Quarantine: ${DESELECT[*]}"
-          XDIST=()
-          [ "$MODE" = "xdist" ] && XDIST=(-n auto)
-          echo "Shard '$SHARD' ($MODE): $TARGETS"
-          set +e
-          # shellcheck disable=SC2086 (TARGETS is an intentional target list)
-          uv run --with pytest-xdist python -m pytest $TARGETS "${XDIST[@]}" \
-            "${DESELECT[@]}" --tb=short --junitxml="test-results-${SHARD}.xml"
-          rc=$?
-          set -e
-          # exit code 5 = "no tests collected" (empty / norecursedirs-excluded
-          # shard) — not a failure for a per-domain shard.
-          if [ "$rc" -eq 5 ]; then
-            echo "::notice::shard '$SHARD' collected no tests — treating as pass"
-            rc=0
-          fi
-          exit "$rc"
-
-      - name: Upload domain test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-results-${{ matrix.name }}
-          path: test-results-*.xml
-          if-no-files-found: ignore
-
-  # --------------------------------------------------------- aggregate gate --
-  # REQUIRED status check — name MUST stay "Run Tests" so branch protection is
-  # unchanged. Green only when the gates job and every domain job pass.
-  tests:
-    name: Run Tests
-    needs: [gates, discover, test-domain]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Aggregate results
-        run: |
-          echo "gates:       ${{ needs.gates.result }}"
-          echo "discover:    ${{ needs.discover.result }}"
-          echo "test-domain: ${{ needs.test-domain.result }}"
-          echo "scope:       ${{ needs.discover.outputs.scope }}"
-          if [ "${{ needs.gates.result }}" != "success" ]; then
-            echo "::error::non-test gates failed (hygiene / repo-structure / wheel)"
-            exit 1
-          fi
-          if [ "${{ needs.discover.result }}" != "success" ]; then
-            echo "::error::domain discovery failed"; exit 1
-          fi
-          # test-domain is a matrix; its result is 'success' only when every
-          # domain job passed (fail-fast is off, so all run to completion).
-          if [ "${{ needs.test-domain.result }}" != "success" ]; then
-            echo "::error::one or more domain jobs failed — see the Domain * jobs"
-            exit 1
-          fi
-          echo "All gates + domains green"
+  # core), so a red domain no longer blocks green siblings and they run in
+  # parallel. Both default paths (selector + quarantine-file) already match
+  # this repo, so only install-cmd needs an override (--group test, not
+  # --all-extras).
+  #
+  # NOTE: status-check names become "<caller-job>/<reusable-job>", e.g.
+  # "domain-tests / Aggregate domain results" — the required check to wire if
+  # branch protection is ever enabled (currently unprotected, so the rename is
+  # harmless).
+  domain-tests:
+    uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
+    with:
+      install-cmd: "uv sync --group test"


### PR DESCRIPTION
## What

Migrate this repo's per-domain CI from inlined `discover -> test-domain (matrix) -> aggregate` jobs to a single caller of workspace-hub's shared reusable workflow [`domain-matrix.yml`](https://github.com/vamseeachanta/workspace-hub/blob/main/.github/workflows/domain-matrix.yml).

This consumes the reusable workflow merged for the per-domain-CI epic — worldenergydata#526 / worldenergydata#530 (P4). **assetutilities is the first real caller.**

## Why

The discover/test-domain/aggregate scaffolding was duplicated across worldenergydata, assetutilities, and assethold. It now lives in ONE place; callers keep only their repo-specific selector. Behavior is identical.

## Changes

`.github/workflows/tests.yml`:
- **Kept** the `Gates` job as-is (source hygiene + repo-structure contract + assetutilities#88 wheel-package-data guard).
- **Kept** `scripts/ci/select_test_targets.py` + `scripts/ci/quarantine.txt` — the reusable workflow invokes them. Both paths match the reusable defaults (`selector`, `quarantine-file`), so no override needed.
- **Deleted** the inlined `discover` / `test-domain` / aggregate (`tests`) jobs (-136 lines), replaced with:

```yaml
domain-tests:
  uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
  with:
    install-cmd: "uv sync --group test"
```

- Only `install-cmd` is overridden (reusable default is `uv sync --all-extras`; this repo uses `--group test`). `python-version` (3.11), `test-runner`, `max-parallel` (10) defaults already suit this repo. `test-runner` default `uv run --with pytest-xdist pytest` is equivalent to the old `uv run --with pytest-xdist python -m pytest`.

## Status-check name change

Reusable-workflow checks are named `<caller-job>/<reusable-job>`, so they become:
- `domain-tests / Discover domains`
- `domain-tests / Domain <name>`
- `domain-tests / Aggregate domain results` ← the gate to require if protection is added

This repo's `main` is currently **unprotected**, so the rename is harmless (no required checks to update).

## Note on push/dispatch

The reusable `discover` job diffs only `github.event.pull_request.base.sha`. On `push`/`workflow_dispatch` (no PR base SHA) the matrix may be empty; the old inline version fell back to `HEAD~1`/full-tree. PR gating (the primary path) is unaffected.

Do NOT merge — validating the reusable workflow end-to-end via this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)