### PR TITLE
chore(precommit): add legal-sanity-scan hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,17 @@ repos:
         types: [python]
         exclude: ^tests/
 
+  # Legal sanity scan (deny list): workspace-hub R-PRECOMMIT readiness check
+  - repo: local
+    hooks:
+      - id: legal-sanity-scan
+        name: Legal sanity scan (deny list)
+        language: script
+        entry: ../scripts/legal/legal-sanity-scan.sh
+        args: [--repo=assetutilities]
+        pass_filenames: false
+        stages: [pre-commit]
+
   # Repository structure gate (issue #78): prevent new root/generated drift
   - repo: local
     hooks:


### PR DESCRIPTION
Adds the legal-sanity-scan pre-commit hook (mirroring digitalmodel) so workspace-hub nightly readiness check R-PRECOMMIT passes. Config-only change.