### PR TITLE
ci: add uv caching to tests.yml (workspace-hub#3291)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,10 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
         run: uv sync --group test


### PR DESCRIPTION
Implements workspace-hub#3291.

Adds uv dependency caching to the `gates` job in `.github/workflows/tests.yml`: bumps `astral-sh/setup-uv` from `@v4` to `@v7` and adds `enable-cache: true` + `cache-dependency-glob: "uv.lock"`, copying the sanctioned worldenergydata `ci.yml` / `domain-matrix.yml` pattern.

Scope per owner decision D2: this is the single local `setup-uv` site in the repo; the `domain-tests` job already inherits caching from the reusable `domain-matrix.yml@main` workflow.

**Verification:** YAML parses (`yaml.safe_load`); the edit matches the locked pattern (`enable-cache` + `cache-dependency-glob: uv.lock`, pinned `@v7`). A real cache hit is observable in the Actions log on a second run over an unchanged `uv.lock` — this repo's `pull_request` trigger has no `paths:` filter, so the PR itself exercises the workflow.