### PR TITLE
feat(engine): embeddable engine — injected root, no cwd side effects (workspace-hub#3297)

### DIFF
--- a/src/assetutilities/common/ApplicationManager.py
+++ b/src/assetutilities/common/ApplicationManager.py
@@ -98,16 +98,85 @@ class ConfigureApplicationInputs:
     def __init__(self):
         pass
 
-    def configure(self, run_dict, library_name, basename, cfg_argv_dict, inputfile=None):
+    def configure(
+        self,
+        run_dict,
+        library_name,
+        basename,
+        cfg_argv_dict,
+        inputfile=None,
+        root_folder=None,
+        log_to_file=True,
+    ):
         cfg = self.unify_application_and_default_and_custom_yamls(
             run_dict, library_name, basename, cfg_argv_dict, inputfile
         )
-        cfg = self.get_application_configuration_parameters(run_dict, basename, cfg)
+        cfg = self.get_application_configuration_parameters(
+            run_dict, basename, cfg, root_folder=root_folder, log_to_file=log_to_file
+        )
         cfg = self.configure_overwrite_filenames(cfg)
         cfg = self.convert_cfg_to_attribute_dictionary(cfg)
         cfg = set_logging(cfg)
 
         # logger.debug(cfg)
+
+        return cfg
+
+    def configure_embed(self, cfg, basename, root_folder, log_to_file=False):
+        """Embeddable configuration for an in-memory cfg (workspace-hub#3297).
+
+        Unlike ``configure``, this does NOT run the
+        ``unify_application_and_default_and_custom_yamls`` step (which discards the
+        caller cfg in favor of the packaged base_config). It dispatches the
+        caller's cfg directly: merges the computed Analysis block INTO the caller
+        cfg, routes all results + logs under the INJECTED ``root_folder`` (never
+        ``os.getcwd()``), and uses no-file logging by default. A per-call instance
+        is expected (see ``engine``) so no ``customYaml``/``CustomInputs`` instance
+        state is touched -> re-entrant.
+        """
+        if cfg is None or root_folder is None:
+            raise ValueError("configure_embed requires both cfg and root_folder")
+
+        application_start_time = datetime.datetime.now()
+
+        custom_file_name = basename
+        label = cfg.get("meta", {}).get("label", None)
+        if label is not None:
+            custom_file_name = custom_file_name + "_" + label
+        file_name = (
+            custom_file_name + "_" + application_start_time.strftime("%Y%m%d_%Hh%Mm")
+        )
+
+        analysis_root_folder = root_folder  # INJECTED, authoritative; never os.getcwd()
+        result_folder_dict, _ = self.configure_result_folder(analysis_root_folder)
+        log_folder = os.path.join(analysis_root_folder, "logs")
+
+        # Config-relative routers (PathResolver) resolve via cfg["_config_dir_path"]
+        # (default os.getcwd()). Rebase it to the injected root so EVERY router's
+        # writes land under root_folder, not cwd.
+        cfg["_config_dir_path"] = analysis_root_folder
+
+        app_config_params = {
+            "Analysis": {
+                "basename": basename,
+                "analysis_root_folder": analysis_root_folder,
+                "file_name": file_name,
+                "file_name_for_overwrite": custom_file_name,
+                "log_folder": log_folder,
+                "log_to_file": log_to_file,
+                "start_time": application_start_time,
+                "cfg_array_file_names": None,
+                "DefaultInputFile": cfg.get("default_yaml", None),
+                "CustomInputFile": None,
+            }
+        }
+        app_config_params["Analysis"] = update_deep_dictionary(
+            app_config_params["Analysis"], result_folder_dict
+        )
+        cfg = update_deep_dictionary(cfg, app_config_params)
+        cfg = self.configure_overwrite_filenames(cfg)
+        cfg = self.convert_cfg_to_attribute_dictionary(cfg)
+        cfg = set_logging(cfg)
 
         return cfg
 
@@ -237,7 +306,9 @@ class ConfigureApplicationInputs:
 
         return cfg
 
-    def get_application_configuration_parameters(self, run_dict, basename, cfg):
+    def get_application_configuration_parameters(
+        self, run_dict, basename, cfg, root_folder=None, log_to_file=True
+    ):
         application_start_time = datetime.datetime.now()
 
         if self.customYaml is not None:
@@ -251,6 +322,13 @@ class ConfigureApplicationInputs:
         else:
             custom_file_name = os.path.split(self.ApplicationInputFile)[1].split(".")[0]
             analysis_root_folder = os.getcwd()
+
+        # Explicit injection override (workspace-hub#3297). When root_folder is
+        # None (every existing caller) the resolved root above is byte-identical
+        # to today, preserving the load-bearing clobber of a stale/relative
+        # Analysis.analysis_root_folder at the update_deep_dictionary merge below.
+        if root_folder is not None:
+            analysis_root_folder = root_folder
 
         filename_label = cfg.get("meta", {}).get("label", None)
         if filename_label is not None:
@@ -266,8 +344,9 @@ class ConfigureApplicationInputs:
         )
 
         log_folder = os.path.join(analysis_root_folder, "logs")
-        if not os.path.exists(log_folder):
-            os.mkdir(log_folder)
+        if log_to_file:
+            if not os.path.exists(log_folder):
+                os.mkdir(log_folder)
 
         cfg_array_file_names = None
 
@@ -278,6 +357,7 @@ class ConfigureApplicationInputs:
                 "file_name": file_name,
                 "file_name_for_overwrite": file_name_for_overwrite,
                 "log_folder": log_folder,
+                "log_to_file": log_to_file,
                 "start_time": application_start_time,
                 "cfg_array_file_names": cfg_array_file_names,
                 "DefaultInputFile": cfg.get("default_yaml", None),

--- a/src/assetutilities/common/set_logging.py
+++ b/src/assetutilities/common/set_logging.py
@@ -13,40 +13,62 @@ def set_logging(cfg):
     if not isinstance(logNumericLevel, int):
         raise ValueError("Invalid log level: {}".format(cfg["default"]["log_level"]))
 
-    # Create log directory if not existing
-    if not os.path.exists(cfg["Analysis"]["log_folder"]):
-        os.makedirs(cfg["Analysis"]["log_folder"])
+    # Embed/no-file mode: when Analysis.log_to_file is False, log only to stdout
+    # and create NO logs/ directory and NO .log file. Default True -> today's
+    # forced-file behavior is unchanged (workspace-hub#3297).
+    log_to_file = cfg["Analysis"].get("log_to_file", True)
 
     # Remove all handlers associated with the root logger object.
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
 
-    # Basic configuration for logging
-    logfilename = os.path.join(
-        cfg["Analysis"]["log_folder"], cfg["Analysis"]["file_name"] + ".log"
-    )
-    logging.basicConfig(
-        # handlers=[InterceptHandler()],
-        level=logNumericLevel,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        datefmt="%m/%d/%Y %I:%M:%S %p",
-        filename=logfilename,
-        filemode="w",
-        force=True,
-    )
+    if log_to_file:
+        # Create log directory if not existing (only when writing a file).
+        if not os.path.exists(cfg["Analysis"]["log_folder"]):
+            os.makedirs(cfg["Analysis"]["log_folder"])
 
-    logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
-    logging.info("Logging started successfully ...")
-
-    config = {
-        "handlers": [
+        # Basic configuration for logging
+        logfilename = os.path.join(
+            cfg["Analysis"]["log_folder"], cfg["Analysis"]["file_name"] + ".log"
+        )
+        logging.basicConfig(
+            # handlers=[InterceptHandler()],
+            level=logNumericLevel,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%m/%d/%Y %I:%M:%S %p",
+            filename=logfilename,
+            filemode="w",
+            force=True,
+        )
+        loguru_handlers = [
             {
                 "sink": sys.stdout,
                 "format": "{time} - {name} - {level} - {message}",
                 "level": log_level,
             },
             {"sink": logfilename, "serialize": True, "level": log_level},
-        ],
+        ]
+    else:
+        logging.basicConfig(
+            level=logNumericLevel,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%m/%d/%Y %I:%M:%S %p",
+            stream=sys.stdout,
+            force=True,
+        )
+        loguru_handlers = [
+            {
+                "sink": sys.stdout,
+                "format": "{time} - {name} - {level} - {message}",
+                "level": log_level,
+            },
+        ]
+
+    logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
+    logging.info("Logging started successfully ...")
+
+    config = {
+        "handlers": loguru_handlers,
         # "extra": {"user": "someone"},
     }
     logger.configure(**config)

--- a/src/assetutilities/engine.py
+++ b/src/assetutilities/engine.py
@@ -24,7 +24,28 @@ fm = FileManagement()
 wwyaml = WorkingWithYAML()
 
 
-def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) -> dict:
+def engine(
+    inputfile: str = None,
+    cfg: dict = None,
+    config_flag: bool = True,
+    root_folder: str = None,
+    log_to_file: bool = True,
+    embed: bool = False,
+) -> dict:
+    """Run an assetutilities workflow.
+
+    Additive params (workspace-hub#3297); defaults are byte-identical to today's
+    behavior:
+
+    - ``root_folder`` (default None): on the file/default path, explicitly
+      override the resolved ``analysis_root_folder`` so all outputs land under
+      this dir. None => today's os.getcwd()/input-file-dir resolution.
+    - ``log_to_file`` (default True): consumed only by the ``embed`` path; the
+      file/default path keeps its forced-file logging regardless.
+    - ``embed`` (default False): when True, dispatch the caller's in-memory
+      ``cfg`` directly under ``root_folder`` (re-entrant, sandboxed, no-file
+      logging) -- the embeddable run path #3282 consumes.
+    """
     cfg_argv_dict = {}
     if cfg is None:
         inputfile, cfg_argv_dict = app_manager.validate_arguments_run_methods(inputfile)
@@ -40,9 +61,22 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
     else:
         raise ValueError("basename not found in cfg")
 
-    if config_flag:
+    if embed:
+        # ---- EMBEDDABLE RUN PATH (the crux #3282 uses) ----
+        # Per-call instance => no module-singleton re-entrancy (does not touch
+        # customYaml/CustomInputs). Dispatches the caller cfg directly under the
+        # injected root; raises ValueError if cfg/root_folder missing.
+        cfg_base = ConfigureApplicationInputs().configure_embed(
+            cfg, basename, root_folder, log_to_file=log_to_file
+        )
         fm = FileManagement()
-        cfg_base = app_manager.configure(cfg, library_name, basename, cfg_argv_dict, inputfile)
+        cfg_base = fm.router(cfg_base)
+    elif config_flag:
+        fm = FileManagement()
+        cfg_base = app_manager.configure(
+            cfg, library_name, basename, cfg_argv_dict, inputfile,
+            root_folder=root_folder,
+        )
         cfg_base = fm.router(cfg_base)
         result_folder_dict, cfg_base = app_manager.configure_result_folder(
             None, cfg_base

--- a/tests/common/test_engine_embeddable_root.py
+++ b/tests/common/test_engine_embeddable_root.py
@@ -1,0 +1,290 @@
+"""Tests for the embeddable assetutilities engine (workspace-hub#3297).
+
+Two additive mechanisms, both defaulting to today's exact behavior:
+
+1. ``root_folder`` parameter threaded through ``engine`` -> ``configure`` ->
+   ``get_application_configuration_parameters`` -> ``configure_result_folder`` ->
+   ``set_logging``. When ``None`` (every existing caller) resolution is
+   byte-identical to today.
+2. A dedicated embed run path (``engine(cfg=..., embed=True, root_folder=<dir>)``
+   / ``ConfigureApplicationInputs.configure_embed(...)``) that dispatches the
+   caller's in-memory cfg directly (no ``unify`` discard), sandboxes all writes
+   under the injected root, and uses no-file logging.
+
+The backward-compat goldens (``test_default_no_injection_uses_cwd``,
+``test_default_clobber_preserves_cwd_over_stale_preset``,
+``test_cli_path_output_locations_unchanged_golden``) prove the default/CLI path
+is unchanged.
+"""
+
+import glob
+import logging
+import os
+
+import pytest
+
+from assetutilities.common.ApplicationManager import ConfigureApplicationInputs
+from assetutilities.common.set_logging import set_logging
+from assetutilities.engine import engine
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+CSV_1 = os.path.join(
+    REPO_ROOT, "tests", "modules", "data_exploration", "csv", "test_1.csv"
+)
+CSV_2 = os.path.join(
+    REPO_ROOT, "tests", "modules", "data_exploration", "csv", "test_2.csv"
+)
+DF_BASIC_STATS_YML = os.path.join(
+    REPO_ROOT, "tests", "modules", "data_exploration", "df_basic_statistics.yml"
+)
+
+SENTINEL_KEY = "_embed_sentinel_key"
+SENTINEL_VALUE = "embed-sentinel-3297"
+
+
+@pytest.fixture(autouse=True)
+def _restore_cwd_and_logging():
+    """Isolate each test from cwd changes and process-global logging state."""
+    cwd = os.getcwd()
+    yield
+    os.chdir(cwd)
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+
+
+def _embed_cfg():
+    """A complete in-memory data_exploration run cfg with ABSOLUTE input paths
+    (so input resolution is independent of cwd and the injected root) and a
+    sentinel key that only the caller cfg carries."""
+    return {
+        "basename": "data_exploration",
+        "type": {
+            "df_statistics": {"flag": True, "df_array": True, "df": True},
+        },
+        "data": {
+            "type": "csv",
+            "groups": [
+                {"label": "FST1", "file_name": CSV_1},
+                {"label": "FST2", "file_name": CSV_2},
+            ],
+        },
+        "master_settings": {"groups": {"columns": {"x": ["Heading"], "y": ["Cx"]}}},
+        "default": {"log_level": "DEBUG", "config": {"overwrite": {"output": True}}},
+        SENTINEL_KEY: SENTINEL_VALUE,
+    }
+
+
+def _listdir(path):
+    return set(os.listdir(path)) if os.path.isdir(path) else set()
+
+
+# --------------------------------------------------------------------------- #
+# Embed path
+# --------------------------------------------------------------------------- #
+def test_embed_honors_in_memory_cfg(tmp_path):
+    """(crux / MAJOR) the embed path keeps caller cfg keys instead of discarding
+    them, and actually dispatches the caller cfg (output produced)."""
+    root = str(tmp_path / "rootA")
+    os.makedirs(root)
+
+    cfg_out = engine(cfg=_embed_cfg(), embed=True, root_folder=root)
+
+    # caller sentinel survived (merge-not-replace; packaged base_config never loaded)
+    assert cfg_out[SENTINEL_KEY] == SENTINEL_VALUE
+    # workflow actually dispatched on the caller cfg -> result CSVs under root
+    produced = glob.glob(os.path.join(root, "results", "*.csv"))
+    assert produced, "embed run produced no result CSVs under the injected root"
+
+
+def test_embed_rebases_config_dir_path(tmp_path):
+    """(Wave-2 addendum) configure_embed rebases cfg['_config_dir_path'] to the
+    injected root so config-relative routers write under root, not cwd."""
+    root = str(tmp_path / "rootCDP")
+    os.makedirs(root)
+
+    cfg_out = engine(cfg=_embed_cfg(), embed=True, root_folder=root)
+
+    assert cfg_out["_config_dir_path"] == root
+
+
+def test_embed_writes_only_under_root(tmp_path):
+    """embed writes results/{,Data,Plot} under the injected root and nothing at cwd."""
+    root = str(tmp_path / "rootB")
+    os.makedirs(root)
+    scratch_cwd = str(tmp_path / "scratch_cwd")
+    os.makedirs(scratch_cwd)
+    os.chdir(scratch_cwd)
+    before = _listdir(scratch_cwd)
+
+    engine(cfg=_embed_cfg(), embed=True, root_folder=root)
+
+    assert os.path.isdir(os.path.join(root, "results"))
+    assert os.path.isdir(os.path.join(root, "results", "Data"))
+    assert os.path.isdir(os.path.join(root, "results", "Plot"))
+    # cwd untouched: no new logs/ or results/ created at cwd
+    after = _listdir(scratch_cwd)
+    assert after == before, f"embed run wrote to cwd: {after - before}"
+
+
+def test_embed_no_logfile_no_logs_dir(tmp_path):
+    """embed default (log_to_file=False) writes no .log and creates no logs/."""
+    root = str(tmp_path / "rootC")
+    os.makedirs(root)
+    scratch_cwd = str(tmp_path / "scratch_cwd")
+    os.makedirs(scratch_cwd)
+    os.chdir(scratch_cwd)
+
+    engine(cfg=_embed_cfg(), embed=True, root_folder=root, log_to_file=False)
+
+    assert not os.path.isdir(os.path.join(root, "logs")), "embed created logs/ dir"
+    assert not glob.glob(os.path.join(root, "**", "*.log"), recursive=True)
+    assert not glob.glob(os.path.join(scratch_cwd, "**", "*.log"), recursive=True)
+
+
+def test_embed_repeated_calls_reentrant(tmp_path):
+    """(re-entrancy / MAJOR-7) two sequential embed calls with different roots
+    stay isolated -> per-call instance, no customYaml/CustomInputs bleed."""
+    root_a = str(tmp_path / "rootR_A")
+    root_b = str(tmp_path / "rootR_B")
+    os.makedirs(root_a)
+    os.makedirs(root_b)
+
+    engine(cfg=_embed_cfg(), embed=True, root_folder=root_a)
+    engine(cfg=_embed_cfg(), embed=True, root_folder=root_b)
+
+    # each call wrote only under its own root
+    assert glob.glob(os.path.join(root_a, "results", "*.csv"))
+    assert glob.glob(os.path.join(root_b, "results", "*.csv"))
+    # no cross-contamination: A's results dir holds no file naming root_b and vice versa
+    a_results = os.path.join(root_a, "results")
+    b_results = os.path.join(root_b, "results")
+    assert not any("rootR_B" in p for p in os.listdir(a_results))
+    assert not any("rootR_A" in p for p in os.listdir(b_results))
+
+
+def test_embed_requires_cfg_and_root():
+    """configure_embed fails closed when cfg or root_folder is missing."""
+    cai = ConfigureApplicationInputs()
+    with pytest.raises(ValueError):
+        cai.configure_embed(None, "data_exploration", "/tmp/x")
+    with pytest.raises(ValueError):
+        cai.configure_embed(_embed_cfg(), "data_exploration", None)
+
+
+# --------------------------------------------------------------------------- #
+# File / default path: root_folder override
+# --------------------------------------------------------------------------- #
+def test_file_path_root_folder_override(tmp_path):
+    """root_folder param on the file/default path redirects ALL outputs to the
+    injected dir; the input file's own dir gets nothing."""
+    import shutil
+
+    input_dir = str(tmp_path / "input_dir")
+    os.makedirs(input_dir)
+    input_yml = os.path.join(input_dir, "df_basic_statistics.yml")
+    shutil.copy(DF_BASIC_STATS_YML, input_yml)
+    root = str(tmp_path / "override_root")
+    os.makedirs(root)
+
+    # cwd = repo root so the yml's repo-relative csv paths resolve
+    os.chdir(REPO_ROOT)
+    engine(input_yml, root_folder=root)
+
+    assert os.path.isdir(os.path.join(root, "results"))
+    assert glob.glob(os.path.join(root, "results", "*.csv"))
+    assert glob.glob(os.path.join(root, "logs", "*.log"))
+    # input file's own dir untouched (no results/ or logs/ created there)
+    assert not os.path.isdir(os.path.join(input_dir, "results"))
+    assert not os.path.isdir(os.path.join(input_dir, "logs"))
+
+
+# --------------------------------------------------------------------------- #
+# Backward-compat goldens
+# --------------------------------------------------------------------------- #
+def test_default_no_injection_uses_cwd(tmp_path):
+    """(backward-compat) no root_folder, no embed -> default in-memory path
+    resolves root to os.getcwd() and creates <cwd>/logs/*.log + <cwd>/results
+    exactly as today (forced file logging)."""
+    scratch_cwd = str(tmp_path / "default_cwd")
+    os.makedirs(scratch_cwd)
+    os.chdir(scratch_cwd)
+
+    # The default config_flag=True in-memory path discards the caller cfg and
+    # loads the packaged base_config (today's behavior), which carries
+    # repo-relative csv paths unresolvable from this scratch cwd -> dispatch
+    # raises. Folder + log creation happens in configure() BEFORE dispatch, so
+    # we assert today's output-location contract regardless of dispatch outcome.
+    try:
+        engine(cfg=_embed_cfg())
+    except Exception:
+        pass
+
+    assert os.path.isdir(os.path.join(scratch_cwd, "logs"))
+    assert glob.glob(os.path.join(scratch_cwd, "logs", "*.log"))
+    assert os.path.isdir(os.path.join(scratch_cwd, "results"))
+    assert os.path.isdir(os.path.join(scratch_cwd, "results", "Data"))
+    assert os.path.isdir(os.path.join(scratch_cwd, "results", "Plot"))
+
+
+def test_default_clobber_preserves_cwd_over_stale_preset(tmp_path):
+    """(backward-compat / MAJOR-1 regression) a cfg carrying a stale/relative
+    Analysis.analysis_root_folder AND no root_folder still resolves the root to
+    os.getcwd() -- the load-bearing clobber (worldenergydata fixtures rely on it)."""
+    scratch_cwd = str(tmp_path / "clobber_cwd")
+    os.makedirs(scratch_cwd)
+    os.chdir(scratch_cwd)
+
+    cai = ConfigureApplicationInputs()
+    # mimic the unify-step preconditions for the in-memory default path
+    cai.customYaml = None
+    cai.CustomInputs = None
+    cai.ApplicationInputFile = os.path.join("base_configs", "data_exploration.yml")
+
+    cfg = {
+        "Analysis": {"analysis_root_folder": "tests\\test_data\\stale\\results"},
+        "default": {"log_level": "DEBUG", "config": {"overwrite": {"output": True}}},
+    }
+
+    out = cai.get_application_configuration_parameters(
+        None, "data_exploration", cfg, root_folder=None
+    )
+
+    assert out["Analysis"]["analysis_root_folder"] == os.getcwd()
+
+
+def test_cli_path_output_locations_unchanged_golden():
+    """(backward-compat golden) the file-based CLI path lands outputs under the
+    input file's results/ dir, same as the pre-change baseline."""
+    os.chdir(REPO_ROOT)
+    engine(DF_BASIC_STATS_YML)
+
+    results_dir = os.path.join(
+        REPO_ROOT, "tests", "modules", "data_exploration", "results"
+    )
+    assert os.path.isdir(results_dir)
+    assert glob.glob(os.path.join(results_dir, "*.csv"))
+
+
+# --------------------------------------------------------------------------- #
+# set_logging no-file mode
+# --------------------------------------------------------------------------- #
+def test_no_file_mode_makedirs_not_called(tmp_path):
+    """(MINOR-5) with log_to_file=False, set_logging creates no logs/ dir even
+    if log_folder points at a non-existent path; stdout logging still works."""
+    nonexistent = str(tmp_path / "does_not_exist_logs")
+    cfg = {
+        "default": {"log_level": "INFO"},
+        "Analysis": {
+            "log_to_file": False,
+            "log_folder": nonexistent,
+            "file_name": "noop",
+        },
+    }
+
+    out = set_logging(cfg)
+
+    assert not os.path.exists(nonexistent), "no-file mode created the log folder"
+    assert out is cfg
+    logging.info("stdout logging works in no-file mode")


### PR DESCRIPTION
Implements workspace-hub#3297 — the foundational prereq the Deterministic Workflow API epic (#3282/#3283) depends on. Makes the shared assetutilities engine embeddable: an in-process caller can run a real workflow that honors its in-memory cfg and writes **nothing** outside an injected root, with no `os.chdir`. Backward-compat is byte-identical on the default/CLI path.

## Two additive mechanisms (defaults = today's behavior)

1. **`root_folder` param** threaded `engine(root_folder=None)` → `configure()` → `get_application_configuration_parameters()` → `configure_result_folder()`. `None` (every existing caller, all 4 tier-1 repos) → resolution byte-identical to today, preserving the **load-bearing `:280` clobber** the worldenergydata fixtures rely on. Provided on the file/default path → overrides the resolved `analysis_root_folder`.

2. **Embed run path** — `engine(cfg=..., embed=True, root_folder=<dir>)` + new `ConfigureApplicationInputs.configure_embed(cfg, basename, root_folder, log_to_file=False)` (no `library_name`; skips the cfg-discarding `unify` step). Dispatches the caller cfg **directly**, merges `Analysis` **into** the caller cfg (preserves it), routes results + logs under the injected root, rebases `cfg["_config_dir_path"]` to root (so PathResolver-based router writes land under root — Wave-2 addendum), uses a **per-call instance** (re-entrant, no `customYaml`/`CustomInputs` bleed), and no-file logging.

3. **`set_logging`** — `os.makedirs(log_folder)` moved **inside** a `log_to_file` branch (gated on `cfg["Analysis"].get("log_to_file", True)`). No-file mode logs to stdout only, creates no `logs/` dir and no `.log`. Default `True` → today's forced-file behavior unchanged.

> **#3282 hook:** `run_workflow` will call `engine(cfg=..., embed=True, root_folder=<tempdir>, log_to_file=False)` — NOT `config_flag=True` (which silently discards the cfg).

## Tests

`tests/common/test_engine_embeddable_root.py` (new, 11 tests):
- Embed: `honors_in_memory_cfg` (crux), `writes_only_under_root`, `no_logfile_no_logs_dir`, `repeated_calls_reentrant`, `rebases_config_dir_path`, `requires_cfg_and_root`.
- File path: `file_path_root_folder_override`.
- **Backward-compat goldens:** `default_no_injection_uses_cwd`, `default_clobber_preserves_cwd_over_stale_preset` (load-bearing clobber regression), `cli_path_output_locations_unchanged_golden`.
- `no_file_mode_makedirs_not_called`.

**Results:** 11 new passed. Full suite `uv run pytest tests/`: **1319 passed, 3 skipped, 1 xfailed, 2 errors** — the 2 errors are pre-existing (`fixture 'benchmark' not found`, pytest-benchmark plugin absent on clean `origin/main`), unrelated to this change.

Files: `engine.py`, `common/ApplicationManager.py`, `common/set_logging.py` (+ new test). `path_resolver.py` unchanged (the `_config_dir_path` rebase lives in `configure_embed`).