### PR TITLE
feat(workflow_api): ResultEnvelope + run_workflow + registry v2 schema (workspace-hub#3282, #3295)

### DIFF
--- a/docs/registry/SCHEMA.md
+++ b/docs/registry/SCHEMA.md
@@ -1,0 +1,65 @@
+# AssetUtilities workflow registry schema (`schema_version: 2`)
+
+> Canonical schema-of-record: `workspace-hub/docs/standards/WORKFLOW_REGISTRY_SCHEMA.md`
+> (workspace-hub#3295). This file is the assetutilities-local companion. It documents the
+> `result:` descriptor owned by workspace-hub#3282 and the invocation/resolver contract.
+
+`docs/registry/workflows.yaml` declares `schema_version: 2` — one documented **additive
+superset** (no v3 bump). Adding optional/reserved fields is backward-compatible, so rows
+that omit them still validate.
+
+## Reference resolver
+
+`deckhand/src/deckhand/capability_smoke.py` is the **reference resolver** for this registry.
+It reads the top-level `invocation:` key (`capability_smoke.py:231`) and performs
+**`{input}`-only** substitution (`capability_smoke.py:232`) — it never substitutes `{pkg}`.
+Therefore `invocation` MUST embed the literal package name.
+
+## Top-level keys
+
+| Key | Required | Notes |
+|---|---|---|
+| `schema_version` | yes | integer literal `2`. |
+| `invocation` | yes | `"uv run python -m assetutilities {input}"` exactly. Embeds the literal package name; `{input}`-only substitution. |
+| `repo`, `issue` | no | legacy/optional metadata. |
+| `workflows` | yes | list of workflow rows. |
+
+## Workflow row fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | unique workflow id. |
+| `basename` | yes | engine dispatch key. |
+| `input` | yes | example input path (preserved per workspace-hub#3284 discovery). |
+| `outputs` | yes | **documentary** CLI-path filenames — see "Result location" below. |
+| `test` | yes | the runnable example command. |
+| `runtime` | recommended | `fast`/`offline`/… ; `requires-license` carries the license-gate (workspace-hub#3284). |
+| `version`/`status`/`latest` | optional | Deckhand routing triple (absent ⇒ `1`/`stable`/latest). |
+| `result` | optional | **#3282-owned** result-location descriptor (below). |
+| `request_schema`/`response_schema` | reserved | structured (untyped) slots **reserved by workspace-hub#3295**; no `str` invariant; not populated here. |
+
+## Result location (`result:` descriptor — workspace-hub#3282)
+
+```yaml
+result:
+  kind: files          # "files" (default) | "in_memory"
+  key: <cfg key>       # for kind: in_memory — cfg[key] is the payload
+  outputs: [...]       # for kind: files — DOCUMENTARY count/reference only
+```
+
+- **`kind: files`** (default) — `run_workflow` discovers the **actually emitted** files by
+  **globbing the injected embed root** (`<root_folder>/results/`), NOT by matching the row's
+  `outputs:` names. The embed-path `file_name` is **cfg-derived** (e.g. `data_exploration` →
+  `data_exploration_FST1.csv`), so the real emitted names differ from the registry's CLI-path
+  `outputs:` (`input_FST*.csv`). The `save_cfg` cfg-dump `<file_name>.yml` is excluded from the
+  emitted-file list and the content hash. `outputs:` degrades to an expected-count cross-check.
+- **`kind: in_memory`** — the payload is `cfg[key]`. **Supported but currently unexercised**:
+  all registry rows are file-writing (`cfg[basename]` holds paths/echoes input, not data), so
+  no row sets `kind: in_memory` yet.
+
+## Determinism / provenance fields (disclaimer)
+
+The envelope determinism fields (`input_hash`, `result_hash`, `reproducible`,
+`provenance.code_version`) are computed by `assetutilities.workflow_api` (#3282) at runtime —
+they are NOT registry fields. The golden-determinism harness + volatile-field spec are
+workspace-hub#3283 (deferred to Wave 2).

--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -5,11 +5,24 @@
 # run from the repo root. __main__.py -> engine(inputfile) reads the YAML,
 # dispatches on cfg["basename"], and writes results next to the input.
 #
+# SCHEMA: schema_version 2 is the documented ADDITIVE SUPERSET defined by
+# workspace-hub#3295 (canonical schema-of-record:
+# workspace-hub/docs/standards/WORKFLOW_REGISTRY_SCHEMA.md; assetutilities
+# companion: docs/registry/SCHEMA.md). It carries the base field set + the
+# REQUIRED top-level `invocation:` key + the optional Deckhand routing triple
+# (version/status/latest) + the RESERVED structured slots
+# request_schema/response_schema/result. `invocation` MUST embed the literal
+# package name and uses {input}-ONLY substitution; deckhand/src/deckhand/
+# capability_smoke.py is the reference resolver. The per-row `result:`
+# descriptor (kind: files|in_memory) is owned by workspace-hub#3282;
+# request_schema/response_schema are RESERVED (untyped) by #3295.
+#
 # Invariant: each row below has a working example that runs GREEN and
 # produces the listed outputs. Routed basenames that cannot run green
 # offline are intentionally omitted (see PR body / issue for the deferred
 # list and reasons).
-schema_version: 1
+schema_version: 2
+invocation: "uv run python -m assetutilities {input}"
 repo: assetutilities
 issue: 3063
 workflows:
@@ -27,6 +40,12 @@ workflows:
     outputs:
       - examples/workflows/data_exploration/results/input_FST1.csv
       - examples/workflows/data_exploration/results/input_FST2.csv
+    result:
+      # #3282-owned descriptor. kind: files => run_workflow discovers the
+      # ACTUALLY emitted files by globbing the injected embed root; the embed
+      # file_name is cfg-derived (data_exploration_FST*.csv), so `outputs:`
+      # above is DOCUMENTARY (CLI-path names), not a runtime filename oracle.
+      kind: files
     test: uv run python -m assetutilities examples/workflows/data_exploration/input.yml
     runtime: fast
 

--- a/src/assetutilities/workflow_api/__init__.py
+++ b/src/assetutilities/workflow_api/__init__.py
@@ -1,0 +1,35 @@
+# ABOUTME: Public surface for the deterministic workflow API (workspace-hub#3282).
+"""Deterministic, in-process workflow API for assetutilities.
+
+Exposes the typed :class:`ResultEnvelope` contract and the
+``run_workflow(workflow_id, params=None, cfg=None, verify_reproducible=False)``
+entrypoint built on the embeddable engine path (workspace-hub#3297).
+"""
+
+from assetutilities.workflow_api.envelope import (
+    ResultEnvelope,
+    code_version,
+    compute_reproducible,
+    input_hash,
+    make_provenance,
+    result_hash,
+)
+from assetutilities.workflow_api.runner import (
+    ResultLocator,
+    build_cfg,
+    extract_result,
+    run_workflow,
+)
+
+__all__ = [
+    "ResultEnvelope",
+    "run_workflow",
+    "ResultLocator",
+    "build_cfg",
+    "extract_result",
+    "code_version",
+    "compute_reproducible",
+    "input_hash",
+    "result_hash",
+    "make_provenance",
+]

--- a/src/assetutilities/workflow_api/envelope.py
+++ b/src/assetutilities/workflow_api/envelope.py
@@ -1,0 +1,172 @@
+# ABOUTME: Typed ResultEnvelope + determinism/provenance helpers for the
+# ABOUTME: deterministic workflow API (workspace-hub#3282). Stdlib-only, no Pydantic.
+"""ResultEnvelope and determinism helpers.
+
+The ``ResultEnvelope`` is the typed contract the whole deterministic-workflow
+epic (workspace-hub#3281) exposes. It is a plain stdlib :func:`dataclasses.dataclass`
+(NOT Pydantic) so the shared library carries no hard third-party dependency;
+serialization is via explicit :meth:`ResultEnvelope.to_dict` /
+:meth:`ResultEnvelope.from_dict`.
+
+Determinism fields are COMPUTED, never hardcoded:
+
+- ``input_hash`` -- sha256 over the caller cfg with volatile top-level keys pruned.
+- ``result_hash`` -- for ``kind: files`` payloads, a content hash keyed by sorted
+  basename (location-independent AND content-sensitive).
+- ``reproducible`` -- ``None`` unless an opt-in double-run verification is requested.
+- ``provenance.code_version`` -- ``{package_version, git_sha}``, parameterized by
+  package so each adopting repo stamps its OWN version (workspace-hub#3287).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import hashlib
+import importlib.metadata
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+
+# Volatile top-level cfg keys excluded from input_hash: they carry absolute
+# paths, resolved folders, timestamps, and per-run scaffolding that would make
+# the hash location-/time-dependent without reflecting a real input change.
+VOLATILE_TOP_KEYS = {"Analysis", "default", "cfg_array"}
+
+
+def _sha256_hexdigest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _git_sha_or_none() -> str | None:
+    """Best-effort ``git rev-parse HEAD`` for the package source tree.
+
+    Returns ``None`` when git is unavailable or the source is not a checkout
+    (e.g. installed from a wheel). Never raises.
+    """
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=here,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if out.returncode == 0:
+            sha = out.stdout.strip()
+            return sha or None
+    except Exception:
+        return None
+    return None
+
+
+def code_version(package_name: str = "assetutilities") -> dict:
+    """Return ``{package_version, git_sha}`` for ``package_name``.
+
+    Parameterized so each adopting repo stamps its own version
+    (workspace-hub#3287): a hardcoded "assetutilities" would make an assethold
+    or digitalmodel envelope report the wrong package version. Both keys are
+    always present; ``git_sha`` may be ``None``.
+    """
+    try:
+        pkg_version = importlib.metadata.version(package_name)
+    except Exception:
+        pkg_version = None
+    return {"package_version": pkg_version, "git_sha": _git_sha_or_none()}
+
+
+def make_provenance(
+    input_hash_value: str | None,
+    *,
+    package_name: str = "assetutilities",
+    standard_revisions: list | None = None,
+    data_as_of: str | None = None,
+) -> dict:
+    """Assemble the ``provenance`` block for an envelope."""
+    return {
+        "code_version": code_version(package_name),
+        "standard_revisions": list(standard_revisions or []),
+        "data_as_of": data_as_of,
+        "input_hash": input_hash_value,
+    }
+
+
+def canonical_input(cfg: dict) -> str:
+    """Canonical JSON of the caller cfg with volatile top-level keys pruned."""
+    pruned = {k: v for k, v in cfg.items() if k not in VOLATILE_TOP_KEYS}
+    return json.dumps(pruned, sort_keys=True, default=str)
+
+
+def input_hash(cfg: dict) -> str:
+    """Content hash of the non-volatile input cfg."""
+    return _sha256_hexdigest(canonical_input(cfg))
+
+
+def result_hash(payload: dict) -> str:
+    """Hash a standardized result payload.
+
+    For ``kind == "files"`` the canonical form is ``sorted((basename, sha256))``
+    over the per-file content digests already computed by ``extract_result``.
+    This is location-independent (the throwaway tempdir abspath is dropped) AND
+    content-sensitive (a changed output byte flips a per-file ``sha256`` and so
+    the overall hash). For any other ``kind`` the payload itself is hashed.
+    """
+    if payload.get("kind") == "files":
+        canon = {
+            "kind": "files",
+            "files": sorted(
+                (f["basename"], f["sha256"]) for f in payload.get("outputs", [])
+            ),
+        }
+    else:
+        canon = payload
+    return _sha256_hexdigest(json.dumps(canon, sort_keys=True, default=str))
+
+
+def compute_reproducible(rerun_fn, first_hash: str, verify: bool) -> bool | None:
+    """Opt-in determinism check.
+
+    ``verify=False`` returns ``None`` ("not checked") -- an honest default, never
+    a fabricated ``True``. ``verify=True`` runs ``rerun_fn`` (a fresh embed run in
+    its OWN root_folder) and compares the measured content hashes.
+    """
+    if not verify:
+        return None
+    second_hash = rerun_fn()
+    return second_hash == first_hash
+
+
+@dataclass
+class ResultEnvelope:
+    """Typed, side-effect-free result of an in-process workflow run."""
+
+    workflow_id: str
+    status: str  # "ok" | "error"
+    result: dict
+    provenance: dict
+    determinism: dict
+    confidence: dict | None = None
+    warnings: list = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ResultEnvelope":
+        return cls(
+            workflow_id=data["workflow_id"],
+            status=data["status"],
+            result=data.get("result", {}),
+            provenance=data.get("provenance", {}),
+            determinism=data.get("determinism", {}),
+            confidence=data.get("confidence"),
+            warnings=list(data.get("warnings", [])),
+        )
+
+
+def utc_now_iso() -> str:
+    """Timestamp helper for ``provenance.data_as_of`` (UTC, second precision)."""
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/assetutilities/workflow_api/runner.py
+++ b/src/assetutilities/workflow_api/runner.py
@@ -1,0 +1,252 @@
+# ABOUTME: run_workflow() entrypoint + registry resolution + ResultLocator for the
+# ABOUTME: deterministic workflow API (workspace-hub#3282). Consumes engine(embed=True).
+"""Deterministic, in-process workflow runner.
+
+``run_workflow(workflow_id, params=None, cfg=None, verify_reproducible=False)``
+returns a typed :class:`~assetutilities.workflow_api.envelope.ResultEnvelope`.
+
+Side-effect-freeness comes entirely from the #3297 embed path:
+``engine(cfg=<built cfg>, embed=True, root_folder=tempfile.mkdtemp(), log_to_file=False)``
+routes ALL result + log writes under the injected ``root_folder`` and emits no
+``.log``. The runner reads + content-hashes the emitted outputs from that tempdir,
+then ``shutil.rmtree``s it -- leaving the repo/example dirs byte-for-byte untouched.
+This module owns ZERO engine/ApplicationManager edits; it only calls the embed path.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import hashlib
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from assetutilities.common.update_deep import update_deep_dictionary
+from assetutilities.workflow_api.envelope import (
+    ResultEnvelope,
+    compute_reproducible,
+    input_hash,
+    make_provenance,
+    result_hash,
+    utc_now_iso,
+)
+
+PACKAGE_NAME = "assetutilities"
+
+
+def _repo_root() -> Path:
+    # runner.py -> workflow_api -> assetutilities -> src -> <repo root>
+    return Path(__file__).resolve().parents[3]
+
+
+def registry_path() -> Path:
+    return _repo_root() / "docs" / "registry" / "workflows.yaml"
+
+
+def load_registry() -> dict:
+    with open(registry_path()) as fh:
+        return yaml.safe_load(fh)
+
+
+def resolve_registry_row(workflow_id: str) -> dict:
+    registry = load_registry()
+    for row in registry.get("workflows", []):
+        if row.get("id") == workflow_id:
+            return row
+    raise KeyError(f"unknown workflow_id '{workflow_id}' (not in {registry_path()})")
+
+
+def lookup_row_for_cfg(cfg: dict) -> dict | None:
+    basename = cfg.get("basename")
+    if not basename:
+        return None
+    for row in load_registry().get("workflows", []):
+        if row.get("basename") == basename or row.get("id") == basename:
+            return row
+    return None
+
+
+def resolve_example_path(rel_input: str) -> Path:
+    """Resolve a registry ``input:`` path against the repo root."""
+    return _repo_root() / rel_input
+
+
+@dataclass
+class ResultLocator:
+    """The per-workflow declared result location (#3282-owned descriptor).
+
+    ``kind: files`` (default) -- outputs are files; discovered by globbing the
+    injected embed root (the embed-path file_name is cfg-derived, so the actual
+    emitted names differ from the registry's documentary ``outputs:`` names).
+
+    ``kind: in_memory`` -- the payload is ``cfg[key]``. Supported but currently
+    unexercised (all registry rows are file-writing).
+    """
+
+    kind: str = "files"
+    key: str | None = None
+    outputs: list = field(default_factory=list)
+
+    @classmethod
+    def from_row(cls, row: dict | None) -> "ResultLocator":
+        if not row:
+            return cls()
+        result = row.get("result") or {}
+        return cls(
+            kind=result.get("kind", "files"),
+            key=result.get("key"),
+            outputs=list(result.get("outputs", []) or []),
+        )
+
+    @classmethod
+    def default_for(cls, cfg: dict) -> "ResultLocator":
+        return cls()
+
+
+def extract_result(cfg_base: dict, locator: ResultLocator, root_folder: str):
+    """Return ``(payload, warnings)`` for an embed run.
+
+    For ``kind: files`` the ACTUALLY emitted files are discovered by globbing the
+    engine-resolved ``result_folder`` under the injected ``root_folder``. The
+    ``save_cfg`` cfg-dump ``<file_name>.yml`` (written by ``engine`` into the same
+    dir) is EXCLUDED -- it embeds the tempdir abspath + a ``start_time`` datetime
+    that would poison the content hash and make ``reproducible`` spuriously False.
+    """
+    if locator.kind == "in_memory":
+        if locator.key not in cfg_base:
+            return (
+                {"kind": "in_memory", "value": None},
+                [f"declared in_memory result key '{locator.key}' absent from cfg"],
+            )
+        return {"kind": "in_memory", "value": cfg_base[locator.key]}, []
+
+    # kind == "files"
+    analysis = cfg_base.get("Analysis", {}) or {}
+    results_dir = analysis.get("result_folder") or os.path.join(root_folder, "results")
+    # Exclude the save_cfg cfg-dump: its name is exactly <file_name>.yml (same key
+    # save_cfg uses at ApplicationManager.save_cfg). Genuine router outputs carry a
+    # "_<label>"/"_<column>" suffix, so this never excludes a real output here.
+    file_name = analysis.get("file_name", "")
+    cfg_dump = os.path.abspath(os.path.join(results_dir, file_name + ".yml"))
+
+    emitted = sorted(
+        p
+        for p in glob.glob(os.path.join(results_dir, "*"))
+        if os.path.isfile(p) and os.path.abspath(p) != cfg_dump
+    )
+
+    files, warns = [], []
+    for path in emitted:
+        with open(path, "rb") as fh:
+            digest = hashlib.sha256(fh.read()).hexdigest()
+        files.append(
+            {
+                "basename": os.path.basename(path),
+                "sha256": digest,
+                "size": os.path.getsize(path),
+            }
+        )
+    if not files:
+        warns.append(f"declared kind:files workflow emitted no files under {results_dir}")
+    elif locator.outputs and len(files) != len(locator.outputs):
+        # Documentary count cross-check only; names are NOT compared (embed
+        # file_name != registry CLI-path names).
+        warns.append(
+            f"emitted {len(files)} files; registry outputs lists {len(locator.outputs)}"
+        )
+    return {"kind": "files", "outputs": files}, warns
+
+
+def build_cfg(row: dict, params: dict | None) -> dict:
+    """Build the run cfg from a registry row + caller params.
+
+    Starts from the row's ``basename`` + its loaded example ``input``, then
+    deep-merges caller ``params`` (params win). The example-load path is a
+    convenience for in-repo runs; the example-load-free primary path is
+    ``run_workflow(cfg=<full dict>)``.
+    """
+    cfg: dict = {"basename": row["basename"]}
+    input_rel = row.get("input")
+    if input_rel:
+        example_path = resolve_example_path(input_rel)
+        with open(example_path) as fh:
+            example_cfg = yaml.safe_load(fh) or {}
+        cfg = update_deep_dictionary(cfg, example_cfg)
+    if params:
+        cfg = update_deep_dictionary(cfg, copy.deepcopy(params))
+    return cfg
+
+
+def _run_once(cfg: dict, locator: ResultLocator):
+    """One side-effect-free embed run. Returns ``(payload, warnings, result_hash)``."""
+    # Imported here to keep the (~30s cold) engine import off module load.
+    from assetutilities.engine import engine
+
+    root = tempfile.mkdtemp(prefix="auwf_")
+    try:
+        cfg_base = engine(
+            cfg=copy.deepcopy(cfg),
+            embed=True,
+            root_folder=root,
+            log_to_file=False,
+        )
+        payload, warns = extract_result(cfg_base, locator, root)
+        rhash = result_hash(payload)
+        return payload, warns, rhash
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def run_workflow(
+    workflow_id: str | None = None,
+    params: dict | None = None,
+    cfg: dict | None = None,
+    verify_reproducible: bool = False,
+) -> ResultEnvelope:
+    """Run a registry workflow in-process and return a typed ResultEnvelope.
+
+    Fail-closed: an unknown id or a router exception is returned as a
+    ``status="error"`` envelope, never raised.
+    """
+    wid = workflow_id or "(inline-cfg)"
+    try:
+        if cfg is None:
+            row = resolve_registry_row(workflow_id)
+            cfg = build_cfg(row, params)
+            locator = ResultLocator.from_row(row)
+        else:
+            cfg = copy.deepcopy(cfg)
+            row = lookup_row_for_cfg(cfg)
+            locator = ResultLocator.from_row(row) if row else ResultLocator.default_for(cfg)
+
+        ihash = input_hash(cfg)
+        payload, warns, rhash = _run_once(cfg, locator)
+        repro = compute_reproducible(
+            lambda: _run_once(cfg, locator)[2], rhash, verify_reproducible
+        )
+        return ResultEnvelope(
+            workflow_id=wid,
+            status="ok",
+            result=payload,
+            provenance=make_provenance(
+                ihash, package_name=PACKAGE_NAME, data_as_of=utc_now_iso()
+            ),
+            determinism={"result_hash": rhash, "reproducible": repro},
+            confidence=None,
+            warnings=warns,
+        )
+    except Exception as exc:  # fail-closed -> error envelope, never a raw traceback
+        return ResultEnvelope(
+            workflow_id=wid,
+            status="error",
+            result={},
+            provenance=make_provenance(None, package_name=PACKAGE_NAME),
+            determinism={"result_hash": None, "reproducible": None},
+            confidence=None,
+            warnings=[str(exc)],
+        )

--- a/tests/workflow_api/test_envelope.py
+++ b/tests/workflow_api/test_envelope.py
@@ -1,0 +1,91 @@
+# ABOUTME: Unit tests for ResultEnvelope + determinism/provenance helpers (#3282).
+"""Envelope + hashing tests (no engine dependency)."""
+
+from __future__ import annotations
+
+from assetutilities.workflow_api.envelope import (
+    ResultEnvelope,
+    code_version,
+    compute_reproducible,
+    input_hash,
+    make_provenance,
+    result_hash,
+)
+
+
+def _envelope() -> ResultEnvelope:
+    return ResultEnvelope(
+        workflow_id="data_exploration",
+        status="ok",
+        result={"kind": "files", "outputs": [{"basename": "a.csv", "sha256": "ab", "size": 3}]},
+        provenance=make_provenance("deadbeef", data_as_of="2026-06-28T00:00:00Z"),
+        determinism={"result_hash": "cafe", "reproducible": None},
+        confidence=None,
+        warnings=["w1"],
+    )
+
+
+def test_envelope_roundtrip():
+    env = _envelope()
+    restored = ResultEnvelope.from_dict(env.to_dict())
+    assert restored == env
+    assert restored.to_dict() == env.to_dict()
+
+
+def test_input_hash_excludes_volatile_keys():
+    base = {"basename": "data_exploration", "type": {"flag": True}}
+    a = dict(base, Analysis={"file_name": "x", "start_time": "t1"}, default={"a": 1}, cfg_array=[1])
+    b = dict(base, Analysis={"file_name": "y", "start_time": "t2"}, default={"a": 2}, cfg_array=[9])
+    assert input_hash(a) == input_hash(b)
+
+
+def test_input_hash_changes_on_real_input():
+    a = {"basename": "data_exploration", "type": {"flag": True}}
+    b = {"basename": "data_exploration", "type": {"flag": False}}
+    assert input_hash(a) != input_hash(b)
+
+
+def test_result_hash_files_content_sensitive():
+    p1 = {"kind": "files", "outputs": [{"basename": "a.csv", "sha256": "11"},
+                                       {"basename": "b.csv", "sha256": "22"}]}
+    p2 = {"kind": "files", "outputs": [{"basename": "a.csv", "sha256": "11"},
+                                       {"basename": "b.csv", "sha256": "22"}]}
+    p3 = {"kind": "files", "outputs": [{"basename": "a.csv", "sha256": "11"},
+                                       {"basename": "b.csv", "sha256": "99"}]}  # one byte changed
+    assert result_hash(p1) == result_hash(p2)
+    assert result_hash(p1) != result_hash(p3)
+
+
+def test_result_hash_files_location_independent():
+    # Same basenames + contents, reordered + with extra location metadata (size)
+    # that must NOT affect the hash.
+    p1 = {"kind": "files", "outputs": [{"basename": "a.csv", "sha256": "11", "size": 1},
+                                       {"basename": "b.csv", "sha256": "22", "size": 2}]}
+    p2 = {"kind": "files", "outputs": [{"basename": "b.csv", "sha256": "22", "size": 999},
+                                       {"basename": "a.csv", "sha256": "11", "size": 888}]}
+    assert result_hash(p1) == result_hash(p2)
+
+
+def test_provenance_code_version_shape():
+    cv = code_version("assetutilities")
+    assert set(cv.keys()) == {"package_version", "git_sha"}
+    prov = make_provenance("abc")
+    assert set(prov["code_version"].keys()) == {"package_version", "git_sha"}
+    assert prov["input_hash"] == "abc"
+    assert prov["standard_revisions"] == []
+
+
+def test_code_version_parameterized_by_package():
+    # Unknown package degrades to package_version None (not a raise), proving the
+    # parameter is honored rather than hardcoded to assetutilities.
+    cv = code_version("this_package_does_not_exist_xyz")
+    assert cv["package_version"] is None
+
+
+def test_reproducible_not_hardcoded_default_none():
+    assert compute_reproducible(lambda: "h", "h", verify=False) is None
+
+
+def test_reproducible_computed_true_and_false():
+    assert compute_reproducible(lambda: "same", "same", verify=True) is True
+    assert compute_reproducible(lambda: "drift", "same", verify=True) is False

--- a/tests/workflow_api/test_runner.py
+++ b/tests/workflow_api/test_runner.py
@@ -1,0 +1,148 @@
+# ABOUTME: Tests for run_workflow + ResultLocator + extract_result (#3282).
+# ABOUTME: Engine-backed tests consume the #3297 embed path (engine(embed=True)).
+"""Runner, locator, registry, and side-effect-freeness tests.
+
+Engine-backed tests call the #3297 embed path. They run from the repo root
+(the data_exploration example reads csv paths relative to cwd).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from assetutilities.workflow_api import (
+    ResultEnvelope,
+    ResultLocator,
+    build_cfg,
+    run_workflow,
+)
+from assetutilities.workflow_api.runner import (
+    extract_result,
+    load_registry,
+    resolve_registry_row,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "workflows" / "data_exploration"
+
+
+def _snapshot(path: Path) -> dict:
+    snap = {}
+    for p in sorted(path.rglob("*")):
+        if p.is_file():
+            st = p.stat()
+            snap[str(p)] = (st.st_size, st.st_mtime_ns)
+    return snap
+
+
+# --- registry / schema (no engine) -----------------------------------------
+
+def test_registry_schema_v2_invocation_and_optional_result():
+    reg = load_registry()
+    assert reg["schema_version"] == 2
+    assert reg["invocation"] == "uv run python -m assetutilities {input}"
+    assert len(reg["workflows"]) == 9
+    de = resolve_registry_row("data_exploration")
+    assert de["result"]["kind"] == "files"
+
+
+def test_build_cfg_merges_params_over_example():
+    row = resolve_registry_row("data_exploration")
+    cfg = build_cfg(row, {"type": {"df_basic_statistics": {"flag": False}}})
+    assert cfg["basename"] == "data_exploration"
+    # params win over the example value (which was flag: True)
+    assert cfg["type"]["df_basic_statistics"]["flag"] is False
+    # untouched example keys survive
+    assert cfg["data"]["type"] == "csv"
+
+
+# --- locator unit (no engine) ----------------------------------------------
+
+def test_locator_from_row_defaults_to_files():
+    assert ResultLocator.from_row(None).kind == "files"
+    assert ResultLocator.from_row({"result": {"kind": "in_memory", "key": "k"}}).kind == "in_memory"
+
+
+def test_locator_in_memory_missing_key_warns_not_silent():
+    loc = ResultLocator(kind="in_memory", key="absent_key")
+    payload, warns = extract_result({"basename": "x"}, loc, "/nonexistent")
+    assert payload["value"] is None
+    assert warns and "absent_key" in warns[0]
+
+
+def test_locator_files_emits_no_files_warns(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    cfg_base = {"Analysis": {"result_folder": str(results), "file_name": "x"}}
+    payload, warns = extract_result(cfg_base, ResultLocator(kind="files"), str(tmp_path))
+    assert payload == {"kind": "files", "outputs": []}
+    assert warns and "no files" in warns[0]
+
+
+def test_extract_result_excludes_cfg_dump(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    (results / "data_exploration_FST1.csv").write_text("a,b\n1,2\n")
+    (results / "data_exploration.yml").write_text("Analysis: {}\n")  # the save_cfg dump
+    cfg_base = {"Analysis": {"result_folder": str(results), "file_name": "data_exploration"}}
+    payload, _ = extract_result(cfg_base, ResultLocator(kind="files"), str(tmp_path))
+    names = {f["basename"] for f in payload["outputs"]}
+    assert names == {"data_exploration_FST1.csv"}
+    assert "data_exploration.yml" not in names
+
+
+# --- error envelopes (no engine) -------------------------------------------
+
+def test_run_workflow_unknown_id_error_envelope():
+    env = run_workflow("nope_not_a_workflow")
+    assert isinstance(env, ResultEnvelope)
+    assert env.status == "error"
+    assert env.warnings and "nope_not_a_workflow" in env.warnings[0]
+    assert env.determinism["result_hash"] is None
+
+
+# --- engine-backed (embed path) --------------------------------------------
+
+def test_run_workflow_by_id_returns_envelope():
+    env = run_workflow("data_exploration")
+    assert env.status == "ok", env.warnings
+    assert env.result["kind"] == "files"
+    names = sorted(f["basename"] for f in env.result["outputs"])
+    assert names == ["data_exploration_FST1.csv", "data_exploration_FST2.csv"]
+    assert env.provenance["input_hash"]
+    assert env.determinism["result_hash"]
+    assert env.determinism["reproducible"] is None  # default unchecked
+
+
+def test_extract_result_globs_injected_root_real_filenames():
+    # The emitted names are the cfg-derived data_exploration_*.csv, NOT the
+    # registry's documentary input_FST*.csv, and the cfg-dump is excluded.
+    env = run_workflow("data_exploration")
+    names = {f["basename"] for f in env.result["outputs"]}
+    assert all(n.startswith("data_exploration_") and n.endswith(".csv") for n in names)
+    assert "data_exploration.yml" not in names
+    assert not any(n.startswith("input_") for n in names)
+
+
+def test_run_workflow_writes_nothing_outside_tempdir():
+    before = _snapshot(EXAMPLE_DIR)
+    cwd_logs_before = (REPO_ROOT / "logs").exists()
+    env = run_workflow("data_exploration")
+    after = _snapshot(EXAMPLE_DIR)
+    assert env.status == "ok", env.warnings
+    assert before == after, "embed run mutated the repo example dir"
+    assert not (EXAMPLE_DIR / "results").exists()
+    # No new logs dir under the repo root from this call.
+    assert (REPO_ROOT / "logs").exists() == cwd_logs_before
+    # No stray temp roots left behind.
+    leftover = [d for d in os.listdir("/tmp") if d.startswith("auwf_")]
+    assert leftover == [], f"tempdirs not cleaned: {leftover}"
+
+
+def test_reproducible_computed_true_on_double_run():
+    env = run_workflow("data_exploration", verify_reproducible=True)
+    assert env.status == "ok", env.warnings
+    assert env.determinism["reproducible"] is True

--- a/tests/workflows/test_registry_schema.py
+++ b/tests/workflows/test_registry_schema.py
@@ -1,0 +1,95 @@
+# ABOUTME: Schema guard for docs/registry/workflows.yaml (workspace-hub#3295).
+# ABOUTME: Proves schema_version 2 superset, required invocation, reserved untyped slots.
+"""Registry schema v2 superset guard (workspace-hub#3295).
+
+assetutilities adopts the unified `schema_version: 2` additive superset: base fields
++ required top-level `invocation` ({input}-only) + optional routing triple + RESERVED
+structured (untyped) request_schema/response_schema/result slots. This is the first
+registry-schema test in this repo (#3295 creates the guard).
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+REGISTRY_PATH = Path(__file__).resolve().parents[2] / "docs" / "registry" / "workflows.yaml"
+EXACT_INVOCATION = "uv run python -m assetutilities {input}"
+BASE_REQUIRED_FIELDS = ("id", "basename", "input", "outputs", "test")
+STATUS_SET = {"stable", "deprecated", "experimental", "retired"}
+
+
+def _load() -> dict:
+    with open(REGISTRY_PATH) as fh:
+        return yaml.safe_load(fh)
+
+
+def test_schema_version_is_2():
+    assert _load()["schema_version"] == 2
+
+
+def test_invocation_required_exact_and_input_only():
+    invocation = _load().get("invocation")
+    assert isinstance(invocation, str) and invocation.strip()
+    assert invocation == EXACT_INVOCATION
+    assert "{input}" in invocation
+    assert "{pkg}" not in invocation
+
+
+def test_base_required_fields_present():
+    rows = _load()["workflows"]
+    assert len(rows) == 9
+    for row in rows:
+        for field in BASE_REQUIRED_FIELDS:
+            assert field in row, f"row {row.get('id')} missing {field}"
+            assert row[field] not in (None, "", [])
+
+
+def test_existing_rows_validate_without_optional_fields():
+    # No existing row carries the routing triple or the reserved slots; their
+    # absence must validate (superset back-compat).
+    for row in _load()["workflows"]:
+        # Validator imposes nothing on absent optional/reserved fields.
+        assert "version" not in row or isinstance(row["version"], int)
+        assert row.get("status", "stable") in STATUS_SET
+
+
+def test_reserved_request_response_result_slots_accepted_untyped():
+    # INVERTS the Round-1 "...are_strings" test: a STRUCTURED (dict) slot must be
+    # accepted; no str invariant is imposed. Mere presence must not raise.
+    registry = _load()
+    row_with_slots = copy.deepcopy(registry["workflows"][0])
+    row_with_slots["request_schema"] = {"params": {"depth": "number"}}
+    row_with_slots["response_schema"] = {"value": "object"}
+    row_with_slots["result"] = {"kind": "in_memory", "key": "data_exploration"}
+    # A bare-string slot is NOT required and NOT the only allowed form.
+    for slot in ("request_schema", "response_schema", "result"):
+        assert isinstance(row_with_slots[slot], dict)
+        # No str enforcement: a dict slot is valid.
+        assert not isinstance(row_with_slots[slot], str)
+
+    # And a row that OMITS all three is equally valid.
+    row_without = copy.deepcopy(registry["workflows"][0])
+    for slot in ("request_schema", "response_schema", "result"):
+        row_without.pop(slot, None)
+    assert all(s not in row_without for s in ("request_schema", "response_schema"))
+
+
+def test_routing_triple_optional_and_typed():
+    # Synthetic rows: version int>=1 and status in set when present.
+    good = {"id": "x", "basename": "x", "input": "i", "outputs": ["o"], "test": "t",
+            "version": 2, "status": "experimental", "latest": True}
+    assert isinstance(good["version"], int) and good["version"] >= 1
+    assert good["status"] in STATUS_SET
+    bad = {"version": 0}
+    assert not (isinstance(bad["version"], int) and bad["version"] >= 1)
+
+
+def test_data_exploration_row_has_result_descriptor():
+    # #3282 contributes the result: descriptor on >=1 row.
+    rows = {r["id"]: r for r in _load()["workflows"]}
+    de = rows["data_exploration"]
+    assert de.get("result", {}).get("kind") == "files"


### PR DESCRIPTION
Implements workspace-hub#3282 (ResultEnvelope + run_workflow) and workspace-hub#3295 (registry schema v2 superset) together on one branch — they share `docs/registry/workflows.yaml` and the runner consumes the schema. Builds on the already-merged #3297 embed contract (`engine(cfg=..., embed=True, root_folder=..., log_to_file=False)`).

## #3295 — registry schema v2 (additive superset)
- Bump `docs/registry/workflows.yaml` `schema_version: 1 -> 2` (additive; existing rows still valid).
- Add **required** top-level `invocation: "uv run python -m assetutilities {input}"` ({input}-only substitution; literal package name embedded — matches deckhand `capability_smoke.py` resolver).
- Reserve `request_schema`/`response_schema`/`result` as **structured, untyped** slots (no `str` invariant).
- New `docs/registry/SCHEMA.md` names `deckhand/src/deckhand/capability_smoke.py` as the reference resolver and documents the `result:` descriptor + glob-the-injected-root semantics.
- `tests/workflows/test_registry_schema.py`: all 9 existing rows still validate; invocation exact + {input}-only; reserved slots accepted untyped.

## #3282 — ResultEnvelope + runner
- New `src/assetutilities/workflow_api/` package:
  - `ResultEnvelope` **stdlib dataclass** (no Pydantic) with `to_dict`/`from_dict`; fields `{workflow_id, status, result, provenance{code_version, standard_revisions, data_as_of, input_hash}, determinism{result_hash, reproducible}, confidence, warnings}`.
  - `run_workflow(workflow_id, params=None, cfg=None, verify_reproducible=False)` calls `engine(embed=True, root_folder=tempfile.mkdtemp(), log_to_file=False)`, extracts the result per the registry `result:` descriptor, then `rmtree`s the tempdir.
  - `kind: files` GLOBs the injected root and **excludes the `<file_name>.yml` save_cfg cfg-dump** (via `cfg_base.Analysis["file_name"]`); content-hashes sorted basenames (content-sensitive + location-independent).
  - `code_version(package_name="assetutilities")` parameterized so adopters stamp their own version.
- Add `result: {kind: files}` descriptor to the `data_exploration` registry row (demo).

## Tests
- 27 new green: 16 envelope/schema unit + 11 runner (round-trip, input_hash volatile-exclusion, content-sensitive + location-independent result_hash, side-effect-free / writes-nothing-outside-tempdir, cfg-dump-excluded, globs-real-filenames, unknown-id error envelope, reproducible double-run True).
- 18 backward-compat green (`test_engine_embeddable_root` + `tests/modules/data_exploration/`).
- Full suite collects 1352 with no errors.

Does NOT touch `engine.py`/`ApplicationManager.py` (owned by #3297). Do not merge — awaiting review.