### PR TITLE
chore: ignore transient agent session dirs; drop merge-artifact symlinks

### DIFF
--- a/.claude/skills/data-management~Updated upstream
+++ b/.claude/skills/data-management~Updated upstream
@@ -1,1 +1,0 @@
-../../../.claude/skills/data/analysis/data-management

--- a/.claude/skills/pdf-utilities~Updated upstream
+++ b/.claude/skills/pdf-utilities~Updated upstream
@@ -1,1 +1,0 @@
-../../../.claude/skills/data/documents/pdf-utilities

--- a/.claude/skills/plotly-visualization~Updated upstream
+++ b/.claude/skills/plotly-visualization~Updated upstream
@@ -1,1 +1,0 @@
-../../../.claude/skills/data/visualization/plotly-visualization

--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,8 @@ specs/
 
 # MkDocs build output (regenerated in CI)
 site/
+
+# AI agent session working directories (Codex, Gemini)
+# Transient per-session dirs; aggregated output lives in workspace-hub/.claude/skills/session-logs/
+.codex/Cu*/
+.gemini/Cu*/


### PR DESCRIPTION
Automated cleanup: ignore transient agent scratch + local config; remove merge-artifact symlinks.