### PR TITLE
docs: ecosystem tagline on README + capabilities page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # assetutilities
 
+> *Everyday complex engineering — made deterministically simple.*
+
 Shared engineering utilities for project configuration, file and YAML handling,
 data processing, engineering calculations, unit conversions, visualization, and
 automation workflows.


### PR DESCRIPTION
Adds the ecosystem mantra — "Everyday complex engineering — made deterministically simple." — as an italic one-liner under the README title. This repo has no capabilities page, so the change is README-only. Tagline insertion only; no other content changes.