### PR TITLE
feat(workflow_api): deterministic run-identity contract (#3428)

### DIFF
--- a/src/assetutilities/workflow_api/identity.py
+++ b/src/assetutilities/workflow_api/identity.py
@@ -1,0 +1,486 @@
+# ABOUTME: Deterministic run-identity contract (workspace-hub#3428): canonical
+# ABOUTME: serialization + domain-separated SHA-256 digests + fail-closed identity.
+"""Deterministic run identity.
+
+This module OWNS the canonical serialization for the deterministic-workflow epic
+(workspace-hub#3281) and mints the type-separated SHA-256 identities defined by
+the on-main ``docs/architecture/algorithm-run-dataset-contract.yaml`` ``identity``
+block. It is stdlib-only (``hashlib``, ``decimal``, ``unicodedata``, ``json``,
+``re``) to keep the shared library dependency-free, matching :mod:`envelope`.
+
+Design invariants:
+
+- **Canonical serialization owner = identity.** :func:`canonicalize` implements a
+  compact RFC 8785 (JCS) serializer: UTF-8, object keys sorted by UTF-16 code-unit
+  order, no insignificant whitespace, arrays in declared order. Strings are
+  Unicode-NFC-normalized before hashing; numbers normalize through
+  :class:`decimal.Decimal` with no float round-trip (``1e3 == 1000``,
+  ``5.0 == 5.00 == 5``); ``null``/NA is explicit and never omitted. A physical
+  quantity MUST be an explicit ``{"value": ..., "unit": ...}`` pair -- a bare
+  units-bearing numeric string (``"5 kg"``) is rejected.
+- **Domain separation.** Every digest is prefixed with its identity type AND the
+  :data:`CANONICALIZATION_VERSION`, so different id types never collide on equal
+  component bytes and a scheme change mints new ids deterministically.
+- **Identity is re-derived from a VERIFIED clean context** (a proven-clean commit
+  + declared env/schema pins + canonical inputs). The :class:`ResultEnvelope`
+  ``input_hash`` (volatile-key-pruned) and ``code_version.git_sha`` (best-effort,
+  no clean-tree proof) are EVIDENCE, never identity inputs;
+  :func:`derive_run_identity` deliberately consumes neither.
+- **Fail-closed.** :func:`check_eligibility` rejects dirty tree / unknown-or-shallow
+  revision / unpinned schema / missing environment digest / implicit seed /
+  implicit execution default before any id is minted.
+- ``run_id`` EXCLUDES outputs -- an exact rerun is the SAME ``run_id``. Output
+  equality is a separate ``output_equality_digest`` (owned by #3431) that this
+  module only references as an opaque injected value while owning the
+  mismatch -> reject-without-mutation POLICY (:func:`assert_output_equality`).
+  ``input_set_id`` per-input canonical field membership is #3430's concern; this
+  module consumes ``input_record_id`` values as given.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from decimal import Decimal
+
+# A change to this constant is a change to the serialization scheme; because it
+# participates in every digest, bumping it deterministically mints new ids.
+CANONICALIZATION_VERSION = "identity-jcs-1"
+
+# Default output-equality comparison (the digest itself is owned by #3431).
+OUTPUT_EQUALITY_DEFAULT = "raw_bytes_sha256"
+
+# ---- component contracts (verbatim from the on-main contract yaml) ----------
+ALGORITHM_VERSION_ID_REQUIRED = (
+    "algorithm_id",
+    "semantic_version",
+    "clean_git_commit",
+    "input_schema_version",
+    "output_schema_version",
+    "environment_digest",
+)
+INPUT_RECORD_ID_REQUIRED = (
+    "role",
+    "native_schema_version",
+    "source_snapshot",
+    "transformation_id",
+    "artifact_sha256",
+    "redistribution_rights",
+    "complete_replay_location",
+)
+INPUT_RECORD_ID_FORBIDDEN = (
+    "run_id",
+    "algorithm_version_id",
+    "output_set_id",
+    "attempt_id",
+    "retry_count",
+    "publication_state",
+    "tenant_id",
+    "customer_id",
+    "request_id",
+    "session_id",
+    "user_id",
+)
+RUN_ID_FORBIDDEN = (
+    "output_set_id",
+    "attempt_id",
+    "retry_count",
+    "publication_state",
+    "tenant_id",
+    "customer_id",
+    "request_id",
+    "api_request_id",
+    "session_id",
+    "user_id",
+)
+
+# Terminal, identity-bearing run statuses. ``indeterminate_failure`` is
+# non-terminal and mints NO identity (no attempt/retry identity ever exists:
+# a rerun of the same canonical inputs is the same run_id).
+IDENTITY_BEARING_STATUSES = frozenset({"succeeded", "reproducible_failure"})
+NON_TERMINAL_STATUSES = frozenset({"indeterminate_failure"})
+
+
+class IdentityError(ValueError):
+    """Raised when identity inputs violate the canonical-serialization contract."""
+
+
+class EligibilityError(IdentityError):
+    """Raised (fail-closed) when a run is not eligible to mint an identity."""
+
+
+class OutputMismatchError(IdentityError):
+    """Raised when an exact rerun's output digest differs from the recorded one."""
+
+
+# ---------------------------------------------------------------------------
+# canonical serialization (RFC 8785 / JCS, compact, stdlib-only)
+# ---------------------------------------------------------------------------
+
+# A bare "units-bearing numeric": a number immediately followed by a unit token
+# (letters / % / common symbols) with nothing else. Dates ("2026-07-11") and
+# plain identifiers do not match, so they are not falsely rejected.
+_UNITS_BEARING_RE = re.compile(
+    r"^\s*[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?\s*[A-Za-z%µμ°Ω/·]+\s*$"
+)
+
+
+def _reject_if_units_bearing(text: str) -> None:
+    if _UNITS_BEARING_RE.match(text):
+        raise IdentityError(
+            f"bare units-bearing numeric {text!r} rejected; represent a physical "
+            "quantity as an explicit {'value': ..., 'unit': ...} pair"
+        )
+
+
+def _number_canonical(value) -> str:
+    """Canonical decimal string for a number (no float round-trip, no exponent)."""
+    if isinstance(value, bool):  # defensive; bool handled before this is reached
+        raise IdentityError("bool is not a number")
+    if isinstance(value, float):
+        # str(float) yields the shortest round-trippable decimal, so we never
+        # bake in binary-float noise the way Decimal(float) would.
+        if value != value or value in (float("inf"), float("-inf")):
+            raise IdentityError(f"non-finite number not permitted: {value!r}")
+        dec = Decimal(str(value))
+    elif isinstance(value, int):
+        dec = Decimal(value)
+    elif isinstance(value, Decimal):
+        if not value.is_finite():
+            raise IdentityError(f"non-finite number not permitted: {value!r}")
+        dec = value
+    else:  # pragma: no cover - guarded by caller
+        raise IdentityError(f"unsupported numeric type: {type(value).__name__}")
+    if dec == 0:
+        return "0"
+    # normalize() collapses 5.00 -> 5 and 1000 -> 1E+3; format 'f' re-expands to
+    # plain decimal so 1e3, 1000 and Decimal('1E3') all render as "1000".
+    return format(dec.normalize(), "f")
+
+
+def _canon(value) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        _reject_if_units_bearing(value)
+        return json.dumps(unicodedata.normalize("NFC", value), ensure_ascii=False)
+    if isinstance(value, (int, float, Decimal)):
+        return _number_canonical(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canon(v) for v in value) + "]"
+    if isinstance(value, dict):
+        parts = []
+        # RFC 8785: sort object keys by UTF-16 code-unit order.
+        for key in sorted(value, key=lambda k: _utf16_sort_key(k)):
+            if not isinstance(key, str):
+                raise IdentityError(
+                    f"object keys must be strings, got {type(key).__name__}"
+                )
+            enc_key = json.dumps(unicodedata.normalize("NFC", key), ensure_ascii=False)
+            parts.append(enc_key + ":" + _canon(value[key]))
+        return "{" + ",".join(parts) + "}"
+    raise IdentityError(f"cannot canonicalize value of type {type(value).__name__}")
+
+
+def _utf16_sort_key(key) -> bytes:
+    if not isinstance(key, str):
+        raise IdentityError(f"object keys must be strings, got {type(key).__name__}")
+    return unicodedata.normalize("NFC", key).encode("utf-16-be")
+
+
+def canonicalize(value) -> str:
+    """Return the canonical (JCS) serialization of ``value`` as text.
+
+    This is the single canonical-serialization owner for the epic. It is
+    total for JSON-shaped values (``dict``/``list``/``str``/``int``/``float``/
+    ``Decimal``/``bool``/``None``) and raises :class:`IdentityError` for
+    non-serializable values or bare units-bearing numeric strings.
+    """
+    return _canon(value)
+
+
+def canonical_digest(identity_type: str, components) -> str:
+    """SHA-256 hex digest of ``components``, domain-separated by ``identity_type``.
+
+    The digest input is ``"{identity_type}\\n{CANONICALIZATION_VERSION}\\n{canon}"``
+    so (a) different id types never collide on equal component bytes and (b) a
+    serialization-scheme bump mints new ids for the same components.
+    """
+    if not isinstance(identity_type, str) or not identity_type:
+        raise IdentityError("identity_type must be a non-empty string")
+    canon = canonicalize(components)
+    payload = f"{identity_type}\n{CANONICALIZATION_VERSION}\n{canon}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# membership validation
+# ---------------------------------------------------------------------------
+
+def _validate_membership(id_type, components, *, required, forbidden=()):
+    if not isinstance(components, dict):
+        raise IdentityError(f"{id_type} components must be a dict")
+    present = set(components)
+    forb = present & set(forbidden)
+    if forb:
+        raise IdentityError(f"{id_type} forbids run-scoped/PII components: {sorted(forb)}")
+    missing = [k for k in required if k not in components or components[k] is None]
+    if missing:
+        raise IdentityError(f"{id_type} missing required components: {missing}")
+    extra = present - set(required)
+    if extra:
+        raise IdentityError(f"{id_type} has unexpected components: {sorted(extra)}")
+
+
+# ---------------------------------------------------------------------------
+# identity constructors
+# ---------------------------------------------------------------------------
+
+def algorithm_version_id(
+    *,
+    algorithm_id,
+    semantic_version,
+    clean_git_commit,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+) -> str:
+    """Mint an ``algorithm_version_id`` binding all six required components.
+
+    ``clean_git_commit`` MUST be a commit already VERIFIED clean/known upstream
+    (see :func:`check_eligibility`); this constructor only binds it.
+    """
+    components = {
+        "algorithm_id": algorithm_id,
+        "semantic_version": semantic_version,
+        "clean_git_commit": clean_git_commit,
+        "input_schema_version": input_schema_version,
+        "output_schema_version": output_schema_version,
+        "environment_digest": environment_digest,
+    }
+    _validate_membership(
+        "algorithm_version_id", components, required=ALGORITHM_VERSION_ID_REQUIRED
+    )
+    return canonical_digest("algorithm_version_id", components)
+
+
+def input_record_id(components: dict) -> str:
+    """Mint an ``input_record_id`` from its required components.
+
+    Rejects the forbidden run-scoped / PII components. The exact canonical field
+    membership beyond required/forbidden is #3430's concern; values are consumed
+    as given.
+    """
+    _validate_membership(
+        "input_record_id",
+        components,
+        required=INPUT_RECORD_ID_REQUIRED,
+        forbidden=INPUT_RECORD_ID_FORBIDDEN,
+    )
+    return canonical_digest("input_record_id", components)
+
+
+def input_set_id(inputs) -> str:
+    """Mint an ``input_set_id`` from ``(role, input_record_id)`` pairs.
+
+    ``inputs`` is an iterable of ``(role, input_record_id)`` tuples or
+    ``{"role": ..., "input_record_id": ...}`` mappings. Pairs are sorted so the
+    set identity is order-independent. ``input_record_id`` values are opaque
+    (they may be produced by #3430) -- this constructor does not re-derive them.
+    """
+    pairs = []
+    for item in inputs:
+        if isinstance(item, dict):
+            role = item["role"]
+            rec_id = item["input_record_id"]
+        else:
+            role, rec_id = item
+        if role is None or rec_id is None:
+            raise IdentityError("each input needs an explicit (role, input_record_id)")
+        pairs.append((role, rec_id))
+    pairs.sort(key=lambda p: (_utf16_sort_key(str(p[0])), _utf16_sort_key(str(p[1]))))
+    components = {
+        "inputs": [{"role": r, "input_record_id": rid} for r, rid in pairs]
+    }
+    return canonical_digest("input_set_id", components)
+
+
+def run_id(*, algorithm_version_id, input_set_id, execution_parameters, seed) -> str:
+    """Mint a ``run_id`` from ``algorithm_version_id`` + ``input_set_id`` +
+    ``execution_parameters`` + ``seed``.
+
+    EXCLUDES outputs (an exact rerun -> same ``run_id``). ``input_set_id`` is an
+    opaque injected digest. ``execution_parameters`` are run-control knobs only
+    (distinct from #3430 ``parameter_set`` inputs) and must not smuggle any
+    run-scoped/PII forbidden component. Seed and execution_parameters must be
+    explicit (fail-closed against implicit defaults).
+    """
+    if seed is None:
+        raise IdentityError("implicit_seed: an explicit seed is required")
+    if execution_parameters is None:
+        raise IdentityError(
+            "implicit_execution_default: explicit execution_parameters are required"
+        )
+    if not isinstance(execution_parameters, dict):
+        raise IdentityError("execution_parameters must be a dict")
+    forb = set(execution_parameters) & set(RUN_ID_FORBIDDEN)
+    if forb:
+        raise IdentityError(
+            f"run_id forbids run-scoped/PII components in execution_parameters: {sorted(forb)}"
+        )
+    if algorithm_version_id is None or input_set_id is None:
+        raise IdentityError("run_id requires algorithm_version_id and input_set_id")
+    components = {
+        "algorithm_version_id": algorithm_version_id,
+        "input_set_id": input_set_id,
+        "execution_parameters": execution_parameters,
+        "seed": seed,
+    }
+    return canonical_digest("run_id", components)
+
+
+# ---------------------------------------------------------------------------
+# fail-closed eligibility
+# ---------------------------------------------------------------------------
+
+def check_eligibility(
+    *,
+    clean_tree: bool,
+    commit,
+    commit_known: bool,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+    seed,
+    execution_parameters,
+) -> bool:
+    """Fail-closed gate: raise :class:`EligibilityError` unless a run may mint id.
+
+    Rejects (all -> reject): ``dirty_source``, ``unknown_revision`` (unknown or
+    shallow commit), ``unpinned_schema``, ``missing_environment_digest``,
+    ``implicit_seed``, ``implicit_execution_default``.
+    """
+    reasons = []
+    if not clean_tree:
+        reasons.append("dirty_source")
+    if not commit_known or not commit:
+        reasons.append("unknown_revision")
+    if not input_schema_version or not output_schema_version:
+        reasons.append("unpinned_schema")
+    if not environment_digest:
+        reasons.append("missing_environment_digest")
+    if seed is None:
+        reasons.append("implicit_seed")
+    if execution_parameters is None:
+        reasons.append("implicit_execution_default")
+    if reasons:
+        raise EligibilityError(f"run not eligible to mint identity: {reasons}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# high-level derivation from a VERIFIED clean context
+# ---------------------------------------------------------------------------
+
+def derive_run_identity(
+    *,
+    algorithm_id,
+    semantic_version,
+    clean_git_commit,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+    inputs,
+    execution_parameters,
+    seed,
+    commit_known: bool = True,
+    clean_tree: bool = True,
+) -> dict:
+    """Re-derive ``{algorithm_version_id, input_set_id, run_id}`` from a VERIFIED
+    clean context.
+
+    Deliberately consumes NEITHER the envelope ``input_hash`` NOR the best-effort
+    ``code_version.git_sha`` -- those are evidence, not identity. Identity binds
+    the ``clean_git_commit`` proven clean here (fail-closed via
+    :func:`check_eligibility`) plus declared env/schema pins plus canonical inputs.
+    Reads nothing from the process environment or cwd, so the same canonical
+    inputs yield the same ``run_id`` on any machine.
+    """
+    check_eligibility(
+        clean_tree=clean_tree,
+        commit=clean_git_commit,
+        commit_known=commit_known,
+        input_schema_version=input_schema_version,
+        output_schema_version=output_schema_version,
+        environment_digest=environment_digest,
+        seed=seed,
+        execution_parameters=execution_parameters,
+    )
+    avid = algorithm_version_id(
+        algorithm_id=algorithm_id,
+        semantic_version=semantic_version,
+        clean_git_commit=clean_git_commit,
+        input_schema_version=input_schema_version,
+        output_schema_version=output_schema_version,
+        environment_digest=environment_digest,
+    )
+    isid = input_set_id(inputs)
+    rid = run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters=execution_parameters,
+        seed=seed,
+    )
+    return {"algorithm_version_id": avid, "input_set_id": isid, "run_id": rid}
+
+
+# ---------------------------------------------------------------------------
+# terminal-status identity semantics
+# ---------------------------------------------------------------------------
+
+def mints_identity(status: str) -> bool:
+    """True iff ``status`` is terminal + identity-bearing (succeeded /
+    reproducible_failure). ``indeterminate_failure`` is non-terminal -> False."""
+    return status in IDENTITY_BEARING_STATUSES
+
+
+def is_terminal_status(status: str) -> bool:
+    return status in IDENTITY_BEARING_STATUSES
+
+
+def run_identity_for_status(status: str, run_id_value: str):
+    """Return ``run_id_value`` for an identity-bearing terminal status, else
+    ``None`` for a non-terminal status (no attempt/retry identity is ever minted).
+    """
+    if status in IDENTITY_BEARING_STATUSES:
+        return run_id_value
+    if status in NON_TERMINAL_STATUSES:
+        return None
+    raise IdentityError(f"unknown run status: {status!r}")
+
+
+# ---------------------------------------------------------------------------
+# output-equality POLICY (digest owned by #3431; policy owned here)
+# ---------------------------------------------------------------------------
+
+def assert_output_equality(recorded_digest, observed_digest, *, prior_record=None) -> bool:
+    """Enforce the output-equality policy for an exact rerun.
+
+    The ``output_equality_digest`` itself is #3431's concern; here we only apply
+    the ``mismatch_action: reject_without_mutation`` POLICY. On mismatch we raise
+    :class:`OutputMismatchError` and mutate NOTHING (``prior_record`` is never
+    written to). Equal digests are accepted.
+    """
+    if recorded_digest != observed_digest:
+        raise OutputMismatchError(
+            "output_equality mismatch under "
+            f"{OUTPUT_EQUALITY_DEFAULT}: recorded={recorded_digest!r} "
+            f"observed={observed_digest!r}; reject_without_mutation"
+        )
+    return True

--- a/tests/workflow_api/test_identity.py
+++ b/tests/workflow_api/test_identity.py
@@ -1,0 +1,411 @@
+# ABOUTME: TDD tests for the deterministic run-identity contract (workspace-hub#3428):
+# ABOUTME: canonical serialization, domain-separated digests, and identity derivation.
+"""Identity contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``identity`` block:
+canonical serialization owned here, SHA-256 digests domain-separated by id type,
+each id binds exactly its declared required components (and rejects the forbidden
+ones), and identity is fail-closed / re-derivable from a verified clean context.
+"""
+
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+
+import pytest
+
+from assetutilities.workflow_api import identity
+
+
+# ---------------------------------------------------------------------------
+# shared fixtures / builders
+# ---------------------------------------------------------------------------
+
+def _avid(**overrides) -> str:
+    kwargs = dict(
+        algorithm_id="stress_screen",
+        semantic_version="1.4.2",
+        clean_git_commit="a" * 40,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-" + "b" * 8,
+    )
+    kwargs.update(overrides)
+    return identity.algorithm_version_id(**kwargs)
+
+
+def _input_record(**overrides) -> dict:
+    rec = dict(
+        role="primary",
+        native_schema_version="ns-1",
+        source_snapshot="snap-2026-07-01",
+        transformation_id="xf-9",
+        artifact_sha256="c" * 64,
+        redistribution_rights="internal",
+        complete_replay_location="s3://bucket/replay/1",
+    )
+    rec.update(overrides)
+    return rec
+
+
+def _derive(**overrides):
+    kwargs = dict(
+        algorithm_id="stress_screen",
+        semantic_version="1.4.2",
+        clean_git_commit="a" * 40,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-" + "b" * 8,
+        inputs=[("primary", "irid-1"), ("aux", "irid-2")],
+        execution_parameters={"tolerance": "1e-6", "mode": "fast"},
+        seed=1234,
+    )
+    kwargs.update(overrides)
+    return identity.derive_run_identity(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. algorithm_version_id binds all required components
+# ---------------------------------------------------------------------------
+
+def test_algorithm_version_id_binds_all_components():
+    base = _avid()
+    changes = {
+        "algorithm_id": "other_algo",
+        "semantic_version": "1.4.3",
+        "clean_git_commit": "d" * 40,
+        "input_schema_version": "in-4",
+        "output_schema_version": "out-3",
+        "environment_digest": "env-" + "e" * 8,
+    }
+    ids = {base}
+    for comp, newval in changes.items():
+        variant = _avid(**{comp: newval})
+        assert variant != base, f"changing {comp} must change algorithm_version_id"
+        ids.add(variant)
+    # every single-component change produced a distinct id
+    assert len(ids) == len(changes) + 1
+
+    # a missing/None required component is rejected (fail-closed), never hashed as absent
+    with pytest.raises(identity.IdentityError):
+        _avid(environment_digest=None)
+
+
+# ---------------------------------------------------------------------------
+# 2. run_id binds its components, excludes outputs, uses input_set_id
+# ---------------------------------------------------------------------------
+
+def test_run_id_binds_components_excludes_outputs():
+    avid = _avid()
+    isid = identity.input_set_id([("primary", "irid-1")])
+    rid = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters={"mode": "fast"},
+        seed=7,
+    )
+    # run_id has no output channel at all -> an output change cannot move it.
+    rid_again = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters={"mode": "fast"},
+        seed=7,
+    )
+    assert rid == rid_again
+
+    # each real component is bound
+    assert rid != identity.run_id(
+        algorithm_version_id=_avid(algorithm_id="x"),
+        input_set_id=isid, execution_parameters={"mode": "fast"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=identity.input_set_id([("primary", "irid-2")]),
+        execution_parameters={"mode": "fast"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid, input_set_id=isid,
+        execution_parameters={"mode": "slow"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid, input_set_id=isid,
+        execution_parameters={"mode": "fast"}, seed=8)
+
+
+# ---------------------------------------------------------------------------
+# 3. canonicalization: equivalent values -> same digest
+# ---------------------------------------------------------------------------
+
+def test_canonicalization_equivalent_values_same_digest():
+    # (a) JCS: object key order + insignificant whitespace are irrelevant.
+    a = {"b": 1, "a": {"y": 2, "x": 3}}
+    b = {"a": {"x": 3, "y": 2}, "b": 1}
+    assert identity.canonicalize(a) == identity.canonicalize(b)
+    assert identity.canonical_digest("t", a) == identity.canonical_digest("t", b)
+
+    # (b) numbers normalize via Decimal, no float round-trip.
+    assert identity.canonicalize(1e3) == identity.canonicalize(1000)
+    assert identity.canonicalize(1000) == identity.canonicalize(Decimal("1E3"))
+    assert identity.canonicalize(5.0) == identity.canonicalize(5)
+    assert identity.canonicalize(5.00) == identity.canonicalize(Decimal("5.00"))
+    assert identity.canonicalize(5) == identity.canonicalize(Decimal("5.00"))
+
+    # (c) Unicode NFC vs NFD forms collapse before hashing.
+    nfc = "é"          # é  (composed)
+    nfd = "é"         # e + combining acute (decomposed)
+    assert nfc != nfd
+    assert identity.canonicalize(nfc) == identity.canonicalize(nfd)
+
+    # (d) a physical quantity MUST be an explicit {value, unit} pair; a bare
+    # units-bearing numeric string is rejected.
+    with pytest.raises(identity.IdentityError):
+        identity.canonicalize("5 kg")
+    with pytest.raises(identity.IdentityError):
+        identity.canonicalize({"mass": "5.0m"})
+    # the explicit pair is accepted
+    identity.canonicalize({"mass": {"value": 5.0, "unit": "kg"}})
+
+
+# ---------------------------------------------------------------------------
+# 4. different inputs never collide (incl. near-collision)
+# ---------------------------------------------------------------------------
+
+def test_different_inputs_never_collide():
+    assert identity.canonical_digest("t", {"v": 1.0}) != identity.canonical_digest(
+        "t", {"v": 1.0000000001})
+    assert identity.canonical_digest("t", [1, 2]) != identity.canonical_digest(
+        "t", [2, 1])  # arrays are ordered
+    assert identity.canonical_digest("t", {"a": 1}) != identity.canonical_digest(
+        "t", {"a": 1, "b": None})  # explicit null is a real difference, not omitted
+
+
+# ---------------------------------------------------------------------------
+# 5. domain separation prevents cross-type collision
+# ---------------------------------------------------------------------------
+
+def test_domain_separation_prevents_cross_type_collision():
+    components = {"role": "primary", "x": 1}
+    a = identity.canonical_digest("algorithm_version_id", components)
+    b = identity.canonical_digest("input_record_id", components)
+    c = identity.canonical_digest("run_id", components)
+    assert len({a, b, c}) == 3, "same bytes under different id types must not collide"
+    # and equal type + equal bytes DO agree (determinism)
+    assert a == identity.canonical_digest("algorithm_version_id", dict(components))
+
+
+# ---------------------------------------------------------------------------
+# 6. canonicalization_version is in every digest and pins the scheme
+# ---------------------------------------------------------------------------
+
+def test_canonicalization_version_in_digests_and_pins_scheme(monkeypatch):
+    before = identity.canonical_digest("t", {"a": 1})
+    assert isinstance(identity.CANONICALIZATION_VERSION, str)
+    monkeypatch.setattr(identity, "CANONICALIZATION_VERSION", "identity-jcs-999")
+    after = identity.canonical_digest("t", {"a": 1})
+    assert before != after, "bumping the scheme version must mint new ids deterministically"
+
+
+# ---------------------------------------------------------------------------
+# 7. fail-closed eligibility
+# ---------------------------------------------------------------------------
+
+def _eligible(**overrides):
+    kwargs = dict(
+        clean_tree=True,
+        commit="a" * 40,
+        commit_known=True,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-1",
+        seed=0,
+        execution_parameters={},
+    )
+    kwargs.update(overrides)
+    return identity.check_eligibility(**kwargs)
+
+
+def test_dirty_or_unpinned_or_implicit_seed_fails_closed():
+    # baseline is eligible
+    assert _eligible() is True
+
+    reject_cases = [
+        dict(clean_tree=False),                       # dirty_source
+        dict(commit_known=False),                     # unknown_revision (shallow/unknown)
+        dict(commit=None),                            # unknown_revision (no commit)
+        dict(input_schema_version=None),              # unpinned_schema
+        dict(output_schema_version=None),             # unpinned_schema
+        dict(environment_digest=None),                # missing_environment_digest
+        dict(seed=None),                              # implicit_seed
+        dict(execution_parameters=None),              # implicit_execution_default
+    ]
+    for case in reject_cases:
+        with pytest.raises(identity.EligibilityError):
+            _eligible(**case)
+
+    # seed == 0 is EXPLICIT (must not be treated as implicit)
+    assert _eligible(seed=0) is True
+
+
+# ---------------------------------------------------------------------------
+# 8. same canonical inputs -> same run_id across machines
+# ---------------------------------------------------------------------------
+
+def test_same_canonical_inputs_same_run_id_cross_machine(monkeypatch, tmp_path):
+    a = _derive()
+    # simulate a different machine: different cwd + different environment
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOSTNAME", "machine-b")
+    monkeypatch.setenv("PWD", str(tmp_path))
+    monkeypatch.setenv("USER", "someone-else")
+    b = _derive()
+    assert a["run_id"] == b["run_id"]
+    assert a["algorithm_version_id"] == b["algorithm_version_id"]
+    assert a["input_set_id"] == b["input_set_id"]
+
+
+# ---------------------------------------------------------------------------
+# 9. any component change changes identity
+# ---------------------------------------------------------------------------
+
+def test_any_component_change_changes_identity():
+    base = _derive()["run_id"]
+    assert _derive(semantic_version="9.9.9")["run_id"] != base
+    assert _derive(clean_git_commit="f" * 40)["run_id"] != base
+    assert _derive(environment_digest="env-other")["run_id"] != base
+    assert _derive(inputs=[("primary", "irid-1"), ("aux", "irid-CHANGED")])["run_id"] != base
+    assert _derive(execution_parameters={"tolerance": "1e-6", "mode": "slow"})["run_id"] != base
+    assert _derive(seed=4321)["run_id"] != base
+
+
+# ---------------------------------------------------------------------------
+# 10. execution_parameters vs parameter_set are not double-counted
+# ---------------------------------------------------------------------------
+
+def test_execution_parameter_and_parameter_set_not_double_counted():
+    # input_set_id depends ONLY on the input records, never on execution_parameters.
+    isid_a = identity.input_set_id([("primary", "irid-1")])
+    isid_b = identity.input_set_id([("primary", "irid-1")])
+    assert isid_a == isid_b
+
+    # A knob living on the execution side moves run_id but NOT input_set_id.
+    r1 = _derive(execution_parameters={"knob": "A"})
+    r2 = _derive(execution_parameters={"knob": "B"})
+    assert r1["input_set_id"] == r2["input_set_id"]   # not leaking into the input side
+    assert r1["run_id"] != r2["run_id"]
+
+    # The same logical value expressed on the INPUT side (a different input record)
+    # moves input_set_id (and run_id) but leaves execution_parameters untouched --
+    # i.e. it is counted on exactly one side, never both.
+    r3 = _derive(inputs=[("primary", "irid-knobA")], execution_parameters={})
+    r4 = _derive(inputs=[("primary", "irid-knobB")], execution_parameters={})
+    assert r3["input_set_id"] != r4["input_set_id"]
+    assert r3["run_id"] != r4["run_id"]
+
+
+# ---------------------------------------------------------------------------
+# 11. run_id uses an opaque injected input_set_id (no #3430 dependency)
+# ---------------------------------------------------------------------------
+
+def test_run_id_uses_opaque_injected_input_set_digest():
+    avid = _avid()
+    opaque = "0" * 64  # a stand-in input_set_id we did not compute here
+    rid = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=opaque,
+        execution_parameters={"mode": "fast"},
+        seed=1,
+    )
+    assert isinstance(rid, str) and len(rid) == 64
+    # a different opaque digest yields a different run_id, with no knowledge of
+    # how the input_set_id was constructed (that is #3430's concern).
+    rid2 = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id="1" * 64,
+        execution_parameters={"mode": "fast"},
+        seed=1,
+    )
+    assert rid != rid2
+
+
+# ---------------------------------------------------------------------------
+# 12. exact-rerun output mismatch fails closed without mutation
+# ---------------------------------------------------------------------------
+
+def test_exact_rerun_output_mismatch_fails_closed_no_mutation():
+    assert identity.OUTPUT_EQUALITY_DEFAULT == "raw_bytes_sha256"
+    prior = {"run_id": "r1", "output_equality_digest": "aa" * 32, "published": True}
+
+    # equal digests -> accepted (no exception)
+    identity.assert_output_equality(prior["output_equality_digest"], "aa" * 32)
+
+    # mismatch -> reject WITHOUT mutating the prior record
+    snapshot = dict(prior)
+    with pytest.raises(identity.OutputMismatchError):
+        identity.assert_output_equality(
+            prior["output_equality_digest"], "bb" * 32, prior_record=prior)
+    assert prior == snapshot, "reject_without_mutation: prior state must be untouched"
+
+
+# ---------------------------------------------------------------------------
+# 13. terminal statuses carry run_id; indeterminate mints none
+# ---------------------------------------------------------------------------
+
+def test_terminal_statuses_have_no_attempt_identity():
+    rid = _derive()["run_id"]
+    assert identity.mints_identity("succeeded") is True
+    assert identity.mints_identity("reproducible_failure") is True
+    assert identity.mints_identity("indeterminate_failure") is False
+
+    assert identity.run_identity_for_status("succeeded", rid) == rid
+    assert identity.run_identity_for_status("reproducible_failure", rid) == rid
+    # non-terminal, non-identity-bearing -> mints NO identity (attempts/retries never do)
+    assert identity.run_identity_for_status("indeterminate_failure", rid) is None
+
+
+# ---------------------------------------------------------------------------
+# 14. input_record_id forbids run-scoped and PII components
+# ---------------------------------------------------------------------------
+
+def test_input_record_id_forbids_run_scoped_and_pii_components():
+    good = identity.input_record_id(_input_record())
+    assert isinstance(good, str) and len(good) == 64
+
+    forbidden_examples = [
+        "run_id", "algorithm_version_id", "output_set_id", "attempt_id",
+        "retry_count", "publication_state", "tenant_id", "customer_id",
+        "request_id", "session_id", "user_id",
+    ]
+    for bad_key in forbidden_examples:
+        rec = _input_record(**{bad_key: "leak"})
+        with pytest.raises(identity.IdentityError):
+            identity.input_record_id(rec)
+
+    # a missing required component is likewise rejected (fail-closed)
+    incomplete = _input_record()
+    del incomplete["artifact_sha256"]
+    with pytest.raises(identity.IdentityError):
+        identity.input_record_id(incomplete)
+
+
+# ---------------------------------------------------------------------------
+# 15. envelope hashes are evidence, never identity inputs
+# ---------------------------------------------------------------------------
+
+def test_envelope_hashes_are_evidence_not_identity():
+    # The identity-derivation entrypoint deliberately consumes NEITHER the
+    # envelope input_hash NOR the best-effort code_version git_sha.
+    params = set(inspect.signature(identity.derive_run_identity).parameters)
+    assert "input_hash" not in params
+    assert "git_sha" not in params
+    for p in params:
+        assert "input_hash" not in p and "git_sha" not in p and "envelope" not in p
+
+    # Concretely: two runs whose ONLY difference is fabricated envelope evidence
+    # (a different volatile input_hash / best-effort git_sha) share one run_id,
+    # because that evidence is never passed into identity.
+    a = _derive()
+    _evidence_a = {"input_hash": "deadbeef", "git_sha": "1111111"}  # noqa: F841 -- not consumed
+    b = _derive()
+    _evidence_b = {"input_hash": "cafef00d", "git_sha": "2222222"}  # noqa: F841 -- not consumed
+    assert a["run_id"] == b["run_id"]
+    # identity is bound to the VERIFIED clean commit, not the best-effort sha
+    assert a["algorithm_version_id"] == b["algorithm_version_id"]


### PR DESCRIPTION
## workspace-hub #3428 — deterministic run identity + algorithm version contract

Reference implementation + TDD proof for the identity root of the run-dataset epic (workspace-hub #3427). Plan-approved (workspace-hub PR #3468). Implements the identity section of the on-`main` `algorithm-run-dataset-contract.yaml`.

**`assetutilities.workflow_api.identity`** (stdlib-only — hashlib/decimal/unicodedata/json, matching `envelope.py`):
- **Pinned canonicalization** — RFC 8785 JCS (UTF-16 code-unit key sort), NFC strings, `Decimal`-normalized numbers with **no float round-trip** (`1e3==1000`, `5.0==5.00==5`), explicit null, bare units-bearing numeric rejected. Versioned by `CANONICALIZATION_VERSION`.
- **Domain-separated SHA-256** digests — each id type is prefixed so `algorithm_version_id`/`input_record_id`/`run_id` never collide on equal bytes (contract `domain_separation_required`).
- `algorithm_version_id`, `input_record_id` (rejects run-scoped/PII forbidden components), `input_set_id`, `run_id` (excludes outputs; opaque-injected `input_set_id`) — exact names from the on-main contract.
- **Fail-closed eligibility** — dirty tree / unknown-or-shallow commit / unpinned schema / missing env digest / implicit seed / implicit execution default all reject.
- Envelope `input_hash` (volatile-pruned) and `git_sha` (best-effort) are **evidence, never identity** — `derive_run_identity()` consumes neither.
- Terminal statuses `succeeded`/`reproducible_failure` mint identity; `indeterminate_failure` mints none; no attempt/retry identity.

**Tests:** 15 first-fail TDD tests → green; full `tests/workflow_api/` suite **35 passed** (9 envelope + 15 identity + 11 runner, nothing broken). `uv run --python 3.11 python -m pytest tests/workflow_api/ -q`.

Refs workspace-hub#3428 workspace-hub#3427 · consumed by workspace-hub#3433 publication module.