### PR TITLE
feat(workflow_api): curated output + rolling report contract (#3431)

### DIFF
--- a/src/assetutilities/workflow_api/__init__.py
+++ b/src/assetutilities/workflow_api/__init__.py
@@ -20,6 +20,12 @@ from assetutilities.workflow_api.runner import (
     extract_result,
     run_workflow,
 )
+from assetutilities.workflow_api.output_contract import (
+    OutputContractError,
+    make_output_record,
+    output_equality_digest,
+)
+from assetutilities.workflow_api.report import render_report
 
 __all__ = [
     "ResultEnvelope",
@@ -32,4 +38,8 @@ __all__ = [
     "input_hash",
     "result_hash",
     "make_provenance",
+    "OutputContractError",
+    "make_output_record",
+    "output_equality_digest",
+    "render_report",
 ]

--- a/src/assetutilities/workflow_api/artifact.py
+++ b/src/assetutilities/workflow_api/artifact.py
@@ -114,14 +114,29 @@ def physical_byte_digest(stored_bytes) -> str:
     return hashlib.sha256(bytes(stored_bytes)).hexdigest()
 
 
-def structured_object_digest(obj) -> str:
-    """Content_digest of a structured object via the JCS canonical form.
+def structured_stored_bytes(obj) -> bytes:
+    """The exact bytes a structured artifact resides as: its JCS canonical form.
 
-    Reuses :func:`identity.canonical_digest` (which hashes
-    ``identity.canonicalize(obj)`` with identity's domain-separation convention),
-    so two key-orderings of one object yield one digest.
+    These are the bytes the object store persists, so a plain re-hash of them
+    reproduces ``content_digest`` (see :func:`structured_object_digest`).
     """
-    return identity.canonical_digest(STRUCTURED_CONTENT_ID_TYPE, obj)
+    return identity.canonicalize(obj).encode("utf-8")
+
+
+def structured_object_digest(obj) -> str:
+    """Content_digest of a structured object = plain SHA-256 of its stored bytes.
+
+    A ``content_digest`` is a CONTENT ADDRESS, not an identity: it must equal a
+    plain ``sha256`` of the exact bytes that reside in the object store so any
+    third party (e.g. the publisher's object-store re-hash in workspace-hub#3433)
+    can revalidate integrity without knowing the artifact's type. The stored bytes
+    of a structured object are its JCS canonical form (:func:`structured_stored_bytes`),
+    so two key-orderings of one object still yield one digest. Domain separation is
+    an *identity* concern (distinguishing algorithm_version_id/run_id) and is
+    deliberately NOT applied here -- it would make the address disagree with a plain
+    byte re-hash.
+    """
+    return hashlib.sha256(structured_stored_bytes(obj)).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/src/assetutilities/workflow_api/artifact.py
+++ b/src/assetutilities/workflow_api/artifact.py
@@ -1,0 +1,381 @@
+# ABOUTME: Content-addressed artifact + HF-residency contract (workspace-hub#3429):
+# ABOUTME: byte-intrinsic SHA-256 identity, integrity-from-bytes, projection-time residency.
+"""Content-addressed artifacts and Hugging Face residency projection.
+
+This module implements the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``artifact`` record --
+``identity: content_digest``, ``residency:
+content_addressed_hf_object_or_explicit_exclusion``, ``dataset_table: artifacts``.
+It is stdlib-only (``hashlib``, ``json`` via :mod:`identity`) to keep the shared
+library dependency-free, matching :mod:`envelope` and :mod:`identity`.
+
+Design invariants (from the approved+remediated #3429 plan):
+
+- **Physical-byte artifact.** ``content_digest = sha256(exact immutable STORED
+  bytes)`` -- TRUE content addressing: this is exactly what a publisher re-hashes
+  from the object on disk. ``compression`` is PURELY DESCRIPTIVE metadata and
+  MUST NEVER trigger decode-before-hash (hashing "decoded" bytes is a rejected
+  design). ``size_bytes`` is the stored byte length.
+- **Structured-object artifact.** ``content_digest`` is derived through
+  :func:`identity.canonical_digest` over :func:`identity.canonicalize` (the single
+  JCS canonical-serialization owner), reusing identity's domain-separation
+  convention. Two key-orderings of one object -> one digest.
+- **Role-free identity.** The Artifact record carries ONLY byte-intrinsic fields
+  (``content_digest, size_bytes, media_type, native_format, compression,
+  schema_ref, storage_locator, license_evidence_ref``). Residency ``class``/role/
+  ``eligible`` live on the referencing Input/Output record, never here. Identical
+  bytes -> ONE artifact record regardless of how many runs/roles reference it.
+- **Integrity-from-bytes.** A reader re-hashes the object's actual bytes and
+  REJECTS any manifest-asserted digest that disagrees -- bytes win, the manifest
+  is untrusted (:func:`verify_integrity`).
+- **Storage-locator safety.** :func:`validate_storage_locator` rejects absolute
+  paths / ``~`` home / UNC (``\\``) / ``..`` traversal and enforces
+  ``storage_locator == "objects/" + content_digest[:2] + "/" + content_digest``.
+- **Residency / exclusion.** Eligibility is computed AT PROJECTION TIME as
+  (byte-intrinsic license evidence) x (per-reference role)
+  (:func:`project_reference_residency`), never stamped on the record. Excluded
+  roles (transient logs / caches / large regenerable dumps) get a VISIBLE
+  ``class: excluded`` marker, never silent omission. A dataset-level license can
+  NEVER grant rights absent from a specific artifact's ``license_evidence_ref``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from assetutilities.workflow_api import identity
+
+# The residency contract value from the on-main artifact record.
+RESIDENCY_CONTRACT = "content_addressed_hf_object_or_explicit_exclusion"
+DATASET_TABLE = "artifacts"
+
+# Projection outcome classes: an eligible reference lands as a content-addressed
+# HF object; anything else is an EXPLICIT exclusion (never silent omission).
+CLASS_HF_OBJECT = "content_addressed_hf_object"
+CLASS_EXCLUDED = "excluded"
+
+# Domain-separation type for a structured-object content_digest, so a structured
+# artifact never collides with a physical blob whose bytes equal the JCS form.
+STRUCTURED_CONTENT_ID_TYPE = "artifact_structured_content"
+
+# The exhaustive byte-intrinsic field set of an Artifact record. Any other field
+# (notably residency class/role/eligible) is forbidden on the record.
+ARTIFACT_FIELDS = (
+    "content_digest",
+    "size_bytes",
+    "media_type",
+    "native_format",
+    "compression",
+    "schema_ref",
+    "storage_locator",
+    "license_evidence_ref",
+)
+
+# Per-reference role policy. HF eligibility is only ever available to a
+# replay-critical public input or a curated native output; transient logs,
+# caches and large regenerable dumps are EXPLICITLY excluded by role. Any other
+# (unknown/ambiguous) role fails closed.
+ELIGIBLE_ROLE_KINDS = frozenset({"replay_critical_input", "curated_native_output"})
+EXCLUDED_ROLE_KINDS = frozenset({"transient_log", "cache", "large_regenerable_dump"})
+
+# License-evidence ``redistribution`` values that fail public projection.
+_NON_PUBLIC_REDISTRIBUTION = frozenset(
+    {"restricted", "client_specific", "non_redistributable", "forbidden"}
+)
+
+
+class ArtifactError(ValueError):
+    """Raised when an artifact record violates the byte-intrinsic contract."""
+
+
+class IntegrityError(ArtifactError):
+    """Raised when actual bytes disagree with a manifest-asserted content_digest."""
+
+
+class StorageLocatorError(ArtifactError):
+    """Raised for an unsafe or record-digest-mismatched storage locator."""
+
+
+# ---------------------------------------------------------------------------
+# content digests
+# ---------------------------------------------------------------------------
+
+def physical_byte_digest(stored_bytes) -> str:
+    """SHA-256 of the EXACT immutable stored bytes (true content addressing).
+
+    ``stored_bytes`` are the bytes as they physically reside in the object store.
+    Compression/encoding is never decoded first -- the digest is what a publisher
+    re-hashes from disk.
+    """
+    if not isinstance(stored_bytes, (bytes, bytearray, memoryview)):
+        raise ArtifactError(
+            f"physical artifact needs raw bytes, got {type(stored_bytes).__name__}"
+        )
+    return hashlib.sha256(bytes(stored_bytes)).hexdigest()
+
+
+def structured_object_digest(obj) -> str:
+    """Content_digest of a structured object via the JCS canonical form.
+
+    Reuses :func:`identity.canonical_digest` (which hashes
+    ``identity.canonicalize(obj)`` with identity's domain-separation convention),
+    so two key-orderings of one object yield one digest.
+    """
+    return identity.canonical_digest(STRUCTURED_CONTENT_ID_TYPE, obj)
+
+
+# ---------------------------------------------------------------------------
+# storage locator
+# ---------------------------------------------------------------------------
+
+def _digest_ok(content_digest) -> bool:
+    return (
+        isinstance(content_digest, str)
+        and len(content_digest) == 64
+        and all(c in "0123456789abcdef" for c in content_digest)
+    )
+
+
+def _validate_digest(content_digest) -> None:
+    if not _digest_ok(content_digest):
+        raise ArtifactError(
+            f"content_digest must be a 64-char lowercase hex SHA-256, got {content_digest!r}"
+        )
+
+
+def storage_locator_for(content_digest) -> str:
+    """Return the canonical sharded locator ``objects/<d[:2]>/<d>`` for a digest."""
+    _validate_digest(content_digest)
+    return "objects/" + content_digest[:2] + "/" + content_digest
+
+
+def _is_unsafe_locator(locator: str) -> bool:
+    if locator.startswith("/") or locator.startswith("~"):
+        return True  # absolute path or home reference
+    if "\\" in locator:
+        return True  # UNC (\\server\share) or a windows/backslash path
+    if ".." in locator.split("/"):
+        return True  # parent-directory traversal
+    return False
+
+
+def validate_storage_locator(locator, content_digest) -> bool:
+    """Validate a storage locator: reject unsafe paths and enforce digest binding.
+
+    Raises :class:`StorageLocatorError` for an absolute / ``~`` / UNC / ``..``
+    locator, or when ``locator != "objects/" + content_digest[:2] + "/" +
+    content_digest`` (shard prefix + full digest tied to the record's digest).
+    """
+    if not isinstance(locator, str) or not locator:
+        raise StorageLocatorError(f"storage_locator must be a non-empty string, got {locator!r}")
+    if _is_unsafe_locator(locator):
+        raise StorageLocatorError(
+            f"unsafe storage_locator {locator!r}: absolute/home/UNC/.. paths are forbidden"
+        )
+    _validate_digest(content_digest)
+    expected = "objects/" + content_digest[:2] + "/" + content_digest
+    if locator != expected:
+        raise StorageLocatorError(
+            f"storage_locator {locator!r} does not match this record's digest "
+            f"(expected {expected!r})"
+        )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# artifact record construction (role-free, byte-intrinsic only)
+# ---------------------------------------------------------------------------
+
+def make_artifact(
+    *,
+    content_digest,
+    size_bytes,
+    media_type,
+    native_format,
+    compression=None,
+    schema_ref=None,
+    storage_locator=None,
+    license_evidence_ref=None,
+    **forbidden,
+) -> dict:
+    """Build a byte-intrinsic Artifact record.
+
+    Rejects any residency ``class``/role/``eligible`` (or otherwise unexpected)
+    field via ``**forbidden`` -- those live on the referencing Input/Output
+    record, never on the artifact. When ``storage_locator`` is omitted it is
+    derived from the digest; when supplied it is validated against the digest.
+    """
+    if forbidden:
+        raise ArtifactError(
+            "artifact record is role-free / byte-intrinsic; forbidden fields: "
+            f"{sorted(forbidden)} (residency class/role/eligible live on the reference)"
+        )
+    _validate_digest(content_digest)
+    if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes < 0:
+        raise ArtifactError(f"size_bytes must be a non-negative int, got {size_bytes!r}")
+    if not media_type or not native_format:
+        raise ArtifactError("media_type and native_format are required byte-intrinsic fields")
+    if storage_locator is None:
+        storage_locator = storage_locator_for(content_digest)
+    else:
+        validate_storage_locator(storage_locator, content_digest)
+    return {
+        "content_digest": content_digest,
+        "size_bytes": size_bytes,
+        "media_type": media_type,
+        "native_format": native_format,
+        "compression": compression,
+        "schema_ref": schema_ref,
+        "storage_locator": storage_locator,
+        "license_evidence_ref": license_evidence_ref,
+    }
+
+
+def physical_artifact(
+    stored_bytes,
+    *,
+    media_type,
+    native_format,
+    compression=None,
+    schema_ref=None,
+    license_evidence_ref=None,
+) -> dict:
+    """Build an Artifact record from the exact stored bytes (content-addressed)."""
+    digest = physical_byte_digest(stored_bytes)
+    return make_artifact(
+        content_digest=digest,
+        size_bytes=len(bytes(stored_bytes)),
+        media_type=media_type,
+        native_format=native_format,
+        compression=compression,
+        schema_ref=schema_ref,
+        license_evidence_ref=license_evidence_ref,
+    )
+
+
+def structured_artifact(
+    obj,
+    *,
+    media_type="application/json",
+    native_format="jcs",
+    compression=None,
+    schema_ref=None,
+    license_evidence_ref=None,
+) -> dict:
+    """Build an Artifact record from a structured object via its JCS canonical form.
+
+    ``size_bytes`` is the byte length of the canonical serialization, so identical
+    objects (any key ordering) produce one identical record.
+    """
+    canon = identity.canonicalize(obj)
+    return make_artifact(
+        content_digest=structured_object_digest(obj),
+        size_bytes=len(canon.encode("utf-8")),
+        media_type=media_type,
+        native_format=native_format,
+        compression=compression,
+        schema_ref=schema_ref,
+        license_evidence_ref=license_evidence_ref,
+    )
+
+
+# ---------------------------------------------------------------------------
+# integrity: re-hash the actual bytes; the manifest is untrusted
+# ---------------------------------------------------------------------------
+
+def verify_integrity(record, *, stored_bytes=None, structured_object=None) -> bool:
+    """Re-hash the object's actual bytes and reject any disagreeing manifest.
+
+    Exactly one of ``stored_bytes`` / ``structured_object`` must be given. The
+    digest is recomputed from that actual object; if it disagrees with
+    ``record["content_digest"]`` we raise :class:`IntegrityError` (bytes win,
+    the manifest is never trusted). This covers both tampered bytes and a
+    hand-forged manifest digest. The storage locator is also re-checked against
+    the recomputed digest.
+    """
+    if (stored_bytes is None) == (structured_object is None):
+        raise ArtifactError("provide exactly one of stored_bytes / structured_object")
+    asserted = record.get("content_digest")
+    if stored_bytes is not None:
+        actual = physical_byte_digest(stored_bytes)
+    else:
+        actual = structured_object_digest(structured_object)
+    if actual != asserted:
+        raise IntegrityError(
+            f"content_digest mismatch: actual bytes hash to {actual} but the "
+            f"manifest asserts {asserted!r}; bytes win, manifest rejected"
+        )
+    locator = record.get("storage_locator")
+    if locator is not None:
+        validate_storage_locator(locator, actual)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# residency projection: eligibility = (byte-license) x (reference-role)
+# ---------------------------------------------------------------------------
+
+def _role_kind(role):
+    return role.get("kind") if isinstance(role, dict) else role
+
+
+def _license_permits_public(evidence):
+    """Return ``(permits, reason)`` for byte-intrinsic license evidence.
+
+    Only unambiguous, publicly-redistributable, non-path-leaking evidence
+    permits public projection. Missing evidence never permits it.
+    """
+    if evidence is None:
+        return False, "no_license_evidence"
+    if not isinstance(evidence, dict):
+        return False, "unstructured_license_evidence"
+    redistribution = evidence.get("redistribution")
+    if redistribution in _NON_PUBLIC_REDISTRIBUTION:
+        return False, f"redistribution_{redistribution}"
+    if redistribution != "public":
+        return False, "redistribution_not_public"
+    license_id = evidence.get("license")
+    if not license_id or license_id == "ambiguous":
+        return False, "ambiguous_license"
+    # a license reference that leaks a filesystem path is not publicly projectable.
+    for value in evidence.values():
+        if isinstance(value, str) and _is_unsafe_locator(value):
+            return False, "path_leak"
+    return True, "public_redistributable"
+
+
+def _excluded(record, reason) -> dict:
+    """A VISIBLE exclusion marker (never silent omission)."""
+    return {
+        "class": CLASS_EXCLUDED,
+        "reason": reason,
+        "content_digest": record.get("content_digest"),
+        "storage_locator": record.get("storage_locator"),
+    }
+
+
+def project_reference_residency(record, role, *, dataset_license=None) -> dict:
+    """Compute residency for one ``(artifact, referencing role)`` at projection time.
+
+    Returns a ``class: content_addressed_hf_object`` marker only when the role is
+    HF-eligible AND the artifact's OWN ``license_evidence_ref`` permits public
+    redistribution; otherwise a VISIBLE ``class: excluded`` marker with a reason.
+    ``dataset_license`` is accepted but can only ever RESTRICT -- it never grants
+    rights absent from the artifact's byte-intrinsic evidence.
+    """
+    kind = _role_kind(role)
+    if kind in EXCLUDED_ROLE_KINDS:
+        return _excluded(record, f"role_excluded:{kind}")
+    if kind not in ELIGIBLE_ROLE_KINDS:
+        return _excluded(record, f"ambiguous_role:{kind}")
+
+    permits, reason = _license_permits_public(record.get("license_evidence_ref"))
+    if not permits:
+        # a dataset-level license is deliberately NOT consulted to grant rights.
+        return _excluded(record, reason)
+    return {
+        "class": CLASS_HF_OBJECT,
+        "reason": f"eligible:{kind}:{reason}",
+        "content_digest": record.get("content_digest"),
+        "storage_locator": record.get("storage_locator"),
+    }

--- a/src/assetutilities/workflow_api/identity.py
+++ b/src/assetutilities/workflow_api/identity.py
@@ -1,0 +1,486 @@
+# ABOUTME: Deterministic run-identity contract (workspace-hub#3428): canonical
+# ABOUTME: serialization + domain-separated SHA-256 digests + fail-closed identity.
+"""Deterministic run identity.
+
+This module OWNS the canonical serialization for the deterministic-workflow epic
+(workspace-hub#3281) and mints the type-separated SHA-256 identities defined by
+the on-main ``docs/architecture/algorithm-run-dataset-contract.yaml`` ``identity``
+block. It is stdlib-only (``hashlib``, ``decimal``, ``unicodedata``, ``json``,
+``re``) to keep the shared library dependency-free, matching :mod:`envelope`.
+
+Design invariants:
+
+- **Canonical serialization owner = identity.** :func:`canonicalize` implements a
+  compact RFC 8785 (JCS) serializer: UTF-8, object keys sorted by UTF-16 code-unit
+  order, no insignificant whitespace, arrays in declared order. Strings are
+  Unicode-NFC-normalized before hashing; numbers normalize through
+  :class:`decimal.Decimal` with no float round-trip (``1e3 == 1000``,
+  ``5.0 == 5.00 == 5``); ``null``/NA is explicit and never omitted. A physical
+  quantity MUST be an explicit ``{"value": ..., "unit": ...}`` pair -- a bare
+  units-bearing numeric string (``"5 kg"``) is rejected.
+- **Domain separation.** Every digest is prefixed with its identity type AND the
+  :data:`CANONICALIZATION_VERSION`, so different id types never collide on equal
+  component bytes and a scheme change mints new ids deterministically.
+- **Identity is re-derived from a VERIFIED clean context** (a proven-clean commit
+  + declared env/schema pins + canonical inputs). The :class:`ResultEnvelope`
+  ``input_hash`` (volatile-key-pruned) and ``code_version.git_sha`` (best-effort,
+  no clean-tree proof) are EVIDENCE, never identity inputs;
+  :func:`derive_run_identity` deliberately consumes neither.
+- **Fail-closed.** :func:`check_eligibility` rejects dirty tree / unknown-or-shallow
+  revision / unpinned schema / missing environment digest / implicit seed /
+  implicit execution default before any id is minted.
+- ``run_id`` EXCLUDES outputs -- an exact rerun is the SAME ``run_id``. Output
+  equality is a separate ``output_equality_digest`` (owned by #3431) that this
+  module only references as an opaque injected value while owning the
+  mismatch -> reject-without-mutation POLICY (:func:`assert_output_equality`).
+  ``input_set_id`` per-input canonical field membership is #3430's concern; this
+  module consumes ``input_record_id`` values as given.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from decimal import Decimal
+
+# A change to this constant is a change to the serialization scheme; because it
+# participates in every digest, bumping it deterministically mints new ids.
+CANONICALIZATION_VERSION = "identity-jcs-1"
+
+# Default output-equality comparison (the digest itself is owned by #3431).
+OUTPUT_EQUALITY_DEFAULT = "raw_bytes_sha256"
+
+# ---- component contracts (verbatim from the on-main contract yaml) ----------
+ALGORITHM_VERSION_ID_REQUIRED = (
+    "algorithm_id",
+    "semantic_version",
+    "clean_git_commit",
+    "input_schema_version",
+    "output_schema_version",
+    "environment_digest",
+)
+INPUT_RECORD_ID_REQUIRED = (
+    "role",
+    "native_schema_version",
+    "source_snapshot",
+    "transformation_id",
+    "artifact_sha256",
+    "redistribution_rights",
+    "complete_replay_location",
+)
+INPUT_RECORD_ID_FORBIDDEN = (
+    "run_id",
+    "algorithm_version_id",
+    "output_set_id",
+    "attempt_id",
+    "retry_count",
+    "publication_state",
+    "tenant_id",
+    "customer_id",
+    "request_id",
+    "session_id",
+    "user_id",
+)
+RUN_ID_FORBIDDEN = (
+    "output_set_id",
+    "attempt_id",
+    "retry_count",
+    "publication_state",
+    "tenant_id",
+    "customer_id",
+    "request_id",
+    "api_request_id",
+    "session_id",
+    "user_id",
+)
+
+# Terminal, identity-bearing run statuses. ``indeterminate_failure`` is
+# non-terminal and mints NO identity (no attempt/retry identity ever exists:
+# a rerun of the same canonical inputs is the same run_id).
+IDENTITY_BEARING_STATUSES = frozenset({"succeeded", "reproducible_failure"})
+NON_TERMINAL_STATUSES = frozenset({"indeterminate_failure"})
+
+
+class IdentityError(ValueError):
+    """Raised when identity inputs violate the canonical-serialization contract."""
+
+
+class EligibilityError(IdentityError):
+    """Raised (fail-closed) when a run is not eligible to mint an identity."""
+
+
+class OutputMismatchError(IdentityError):
+    """Raised when an exact rerun's output digest differs from the recorded one."""
+
+
+# ---------------------------------------------------------------------------
+# canonical serialization (RFC 8785 / JCS, compact, stdlib-only)
+# ---------------------------------------------------------------------------
+
+# A bare "units-bearing numeric": a number immediately followed by a unit token
+# (letters / % / common symbols) with nothing else. Dates ("2026-07-11") and
+# plain identifiers do not match, so they are not falsely rejected.
+_UNITS_BEARING_RE = re.compile(
+    r"^\s*[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?\s*[A-Za-z%µμ°Ω/·]+\s*$"
+)
+
+
+def _reject_if_units_bearing(text: str) -> None:
+    if _UNITS_BEARING_RE.match(text):
+        raise IdentityError(
+            f"bare units-bearing numeric {text!r} rejected; represent a physical "
+            "quantity as an explicit {'value': ..., 'unit': ...} pair"
+        )
+
+
+def _number_canonical(value) -> str:
+    """Canonical decimal string for a number (no float round-trip, no exponent)."""
+    if isinstance(value, bool):  # defensive; bool handled before this is reached
+        raise IdentityError("bool is not a number")
+    if isinstance(value, float):
+        # str(float) yields the shortest round-trippable decimal, so we never
+        # bake in binary-float noise the way Decimal(float) would.
+        if value != value or value in (float("inf"), float("-inf")):
+            raise IdentityError(f"non-finite number not permitted: {value!r}")
+        dec = Decimal(str(value))
+    elif isinstance(value, int):
+        dec = Decimal(value)
+    elif isinstance(value, Decimal):
+        if not value.is_finite():
+            raise IdentityError(f"non-finite number not permitted: {value!r}")
+        dec = value
+    else:  # pragma: no cover - guarded by caller
+        raise IdentityError(f"unsupported numeric type: {type(value).__name__}")
+    if dec == 0:
+        return "0"
+    # normalize() collapses 5.00 -> 5 and 1000 -> 1E+3; format 'f' re-expands to
+    # plain decimal so 1e3, 1000 and Decimal('1E3') all render as "1000".
+    return format(dec.normalize(), "f")
+
+
+def _canon(value) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        _reject_if_units_bearing(value)
+        return json.dumps(unicodedata.normalize("NFC", value), ensure_ascii=False)
+    if isinstance(value, (int, float, Decimal)):
+        return _number_canonical(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canon(v) for v in value) + "]"
+    if isinstance(value, dict):
+        parts = []
+        # RFC 8785: sort object keys by UTF-16 code-unit order.
+        for key in sorted(value, key=lambda k: _utf16_sort_key(k)):
+            if not isinstance(key, str):
+                raise IdentityError(
+                    f"object keys must be strings, got {type(key).__name__}"
+                )
+            enc_key = json.dumps(unicodedata.normalize("NFC", key), ensure_ascii=False)
+            parts.append(enc_key + ":" + _canon(value[key]))
+        return "{" + ",".join(parts) + "}"
+    raise IdentityError(f"cannot canonicalize value of type {type(value).__name__}")
+
+
+def _utf16_sort_key(key) -> bytes:
+    if not isinstance(key, str):
+        raise IdentityError(f"object keys must be strings, got {type(key).__name__}")
+    return unicodedata.normalize("NFC", key).encode("utf-16-be")
+
+
+def canonicalize(value) -> str:
+    """Return the canonical (JCS) serialization of ``value`` as text.
+
+    This is the single canonical-serialization owner for the epic. It is
+    total for JSON-shaped values (``dict``/``list``/``str``/``int``/``float``/
+    ``Decimal``/``bool``/``None``) and raises :class:`IdentityError` for
+    non-serializable values or bare units-bearing numeric strings.
+    """
+    return _canon(value)
+
+
+def canonical_digest(identity_type: str, components) -> str:
+    """SHA-256 hex digest of ``components``, domain-separated by ``identity_type``.
+
+    The digest input is ``"{identity_type}\\n{CANONICALIZATION_VERSION}\\n{canon}"``
+    so (a) different id types never collide on equal component bytes and (b) a
+    serialization-scheme bump mints new ids for the same components.
+    """
+    if not isinstance(identity_type, str) or not identity_type:
+        raise IdentityError("identity_type must be a non-empty string")
+    canon = canonicalize(components)
+    payload = f"{identity_type}\n{CANONICALIZATION_VERSION}\n{canon}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# membership validation
+# ---------------------------------------------------------------------------
+
+def _validate_membership(id_type, components, *, required, forbidden=()):
+    if not isinstance(components, dict):
+        raise IdentityError(f"{id_type} components must be a dict")
+    present = set(components)
+    forb = present & set(forbidden)
+    if forb:
+        raise IdentityError(f"{id_type} forbids run-scoped/PII components: {sorted(forb)}")
+    missing = [k for k in required if k not in components or components[k] is None]
+    if missing:
+        raise IdentityError(f"{id_type} missing required components: {missing}")
+    extra = present - set(required)
+    if extra:
+        raise IdentityError(f"{id_type} has unexpected components: {sorted(extra)}")
+
+
+# ---------------------------------------------------------------------------
+# identity constructors
+# ---------------------------------------------------------------------------
+
+def algorithm_version_id(
+    *,
+    algorithm_id,
+    semantic_version,
+    clean_git_commit,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+) -> str:
+    """Mint an ``algorithm_version_id`` binding all six required components.
+
+    ``clean_git_commit`` MUST be a commit already VERIFIED clean/known upstream
+    (see :func:`check_eligibility`); this constructor only binds it.
+    """
+    components = {
+        "algorithm_id": algorithm_id,
+        "semantic_version": semantic_version,
+        "clean_git_commit": clean_git_commit,
+        "input_schema_version": input_schema_version,
+        "output_schema_version": output_schema_version,
+        "environment_digest": environment_digest,
+    }
+    _validate_membership(
+        "algorithm_version_id", components, required=ALGORITHM_VERSION_ID_REQUIRED
+    )
+    return canonical_digest("algorithm_version_id", components)
+
+
+def input_record_id(components: dict) -> str:
+    """Mint an ``input_record_id`` from its required components.
+
+    Rejects the forbidden run-scoped / PII components. The exact canonical field
+    membership beyond required/forbidden is #3430's concern; values are consumed
+    as given.
+    """
+    _validate_membership(
+        "input_record_id",
+        components,
+        required=INPUT_RECORD_ID_REQUIRED,
+        forbidden=INPUT_RECORD_ID_FORBIDDEN,
+    )
+    return canonical_digest("input_record_id", components)
+
+
+def input_set_id(inputs) -> str:
+    """Mint an ``input_set_id`` from ``(role, input_record_id)`` pairs.
+
+    ``inputs`` is an iterable of ``(role, input_record_id)`` tuples or
+    ``{"role": ..., "input_record_id": ...}`` mappings. Pairs are sorted so the
+    set identity is order-independent. ``input_record_id`` values are opaque
+    (they may be produced by #3430) -- this constructor does not re-derive them.
+    """
+    pairs = []
+    for item in inputs:
+        if isinstance(item, dict):
+            role = item["role"]
+            rec_id = item["input_record_id"]
+        else:
+            role, rec_id = item
+        if role is None or rec_id is None:
+            raise IdentityError("each input needs an explicit (role, input_record_id)")
+        pairs.append((role, rec_id))
+    pairs.sort(key=lambda p: (_utf16_sort_key(str(p[0])), _utf16_sort_key(str(p[1]))))
+    components = {
+        "inputs": [{"role": r, "input_record_id": rid} for r, rid in pairs]
+    }
+    return canonical_digest("input_set_id", components)
+
+
+def run_id(*, algorithm_version_id, input_set_id, execution_parameters, seed) -> str:
+    """Mint a ``run_id`` from ``algorithm_version_id`` + ``input_set_id`` +
+    ``execution_parameters`` + ``seed``.
+
+    EXCLUDES outputs (an exact rerun -> same ``run_id``). ``input_set_id`` is an
+    opaque injected digest. ``execution_parameters`` are run-control knobs only
+    (distinct from #3430 ``parameter_set`` inputs) and must not smuggle any
+    run-scoped/PII forbidden component. Seed and execution_parameters must be
+    explicit (fail-closed against implicit defaults).
+    """
+    if seed is None:
+        raise IdentityError("implicit_seed: an explicit seed is required")
+    if execution_parameters is None:
+        raise IdentityError(
+            "implicit_execution_default: explicit execution_parameters are required"
+        )
+    if not isinstance(execution_parameters, dict):
+        raise IdentityError("execution_parameters must be a dict")
+    forb = set(execution_parameters) & set(RUN_ID_FORBIDDEN)
+    if forb:
+        raise IdentityError(
+            f"run_id forbids run-scoped/PII components in execution_parameters: {sorted(forb)}"
+        )
+    if algorithm_version_id is None or input_set_id is None:
+        raise IdentityError("run_id requires algorithm_version_id and input_set_id")
+    components = {
+        "algorithm_version_id": algorithm_version_id,
+        "input_set_id": input_set_id,
+        "execution_parameters": execution_parameters,
+        "seed": seed,
+    }
+    return canonical_digest("run_id", components)
+
+
+# ---------------------------------------------------------------------------
+# fail-closed eligibility
+# ---------------------------------------------------------------------------
+
+def check_eligibility(
+    *,
+    clean_tree: bool,
+    commit,
+    commit_known: bool,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+    seed,
+    execution_parameters,
+) -> bool:
+    """Fail-closed gate: raise :class:`EligibilityError` unless a run may mint id.
+
+    Rejects (all -> reject): ``dirty_source``, ``unknown_revision`` (unknown or
+    shallow commit), ``unpinned_schema``, ``missing_environment_digest``,
+    ``implicit_seed``, ``implicit_execution_default``.
+    """
+    reasons = []
+    if not clean_tree:
+        reasons.append("dirty_source")
+    if not commit_known or not commit:
+        reasons.append("unknown_revision")
+    if not input_schema_version or not output_schema_version:
+        reasons.append("unpinned_schema")
+    if not environment_digest:
+        reasons.append("missing_environment_digest")
+    if seed is None:
+        reasons.append("implicit_seed")
+    if execution_parameters is None:
+        reasons.append("implicit_execution_default")
+    if reasons:
+        raise EligibilityError(f"run not eligible to mint identity: {reasons}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# high-level derivation from a VERIFIED clean context
+# ---------------------------------------------------------------------------
+
+def derive_run_identity(
+    *,
+    algorithm_id,
+    semantic_version,
+    clean_git_commit,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+    inputs,
+    execution_parameters,
+    seed,
+    commit_known: bool = True,
+    clean_tree: bool = True,
+) -> dict:
+    """Re-derive ``{algorithm_version_id, input_set_id, run_id}`` from a VERIFIED
+    clean context.
+
+    Deliberately consumes NEITHER the envelope ``input_hash`` NOR the best-effort
+    ``code_version.git_sha`` -- those are evidence, not identity. Identity binds
+    the ``clean_git_commit`` proven clean here (fail-closed via
+    :func:`check_eligibility`) plus declared env/schema pins plus canonical inputs.
+    Reads nothing from the process environment or cwd, so the same canonical
+    inputs yield the same ``run_id`` on any machine.
+    """
+    check_eligibility(
+        clean_tree=clean_tree,
+        commit=clean_git_commit,
+        commit_known=commit_known,
+        input_schema_version=input_schema_version,
+        output_schema_version=output_schema_version,
+        environment_digest=environment_digest,
+        seed=seed,
+        execution_parameters=execution_parameters,
+    )
+    avid = algorithm_version_id(
+        algorithm_id=algorithm_id,
+        semantic_version=semantic_version,
+        clean_git_commit=clean_git_commit,
+        input_schema_version=input_schema_version,
+        output_schema_version=output_schema_version,
+        environment_digest=environment_digest,
+    )
+    isid = input_set_id(inputs)
+    rid = run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters=execution_parameters,
+        seed=seed,
+    )
+    return {"algorithm_version_id": avid, "input_set_id": isid, "run_id": rid}
+
+
+# ---------------------------------------------------------------------------
+# terminal-status identity semantics
+# ---------------------------------------------------------------------------
+
+def mints_identity(status: str) -> bool:
+    """True iff ``status`` is terminal + identity-bearing (succeeded /
+    reproducible_failure). ``indeterminate_failure`` is non-terminal -> False."""
+    return status in IDENTITY_BEARING_STATUSES
+
+
+def is_terminal_status(status: str) -> bool:
+    return status in IDENTITY_BEARING_STATUSES
+
+
+def run_identity_for_status(status: str, run_id_value: str):
+    """Return ``run_id_value`` for an identity-bearing terminal status, else
+    ``None`` for a non-terminal status (no attempt/retry identity is ever minted).
+    """
+    if status in IDENTITY_BEARING_STATUSES:
+        return run_id_value
+    if status in NON_TERMINAL_STATUSES:
+        return None
+    raise IdentityError(f"unknown run status: {status!r}")
+
+
+# ---------------------------------------------------------------------------
+# output-equality POLICY (digest owned by #3431; policy owned here)
+# ---------------------------------------------------------------------------
+
+def assert_output_equality(recorded_digest, observed_digest, *, prior_record=None) -> bool:
+    """Enforce the output-equality policy for an exact rerun.
+
+    The ``output_equality_digest`` itself is #3431's concern; here we only apply
+    the ``mismatch_action: reject_without_mutation`` POLICY. On mismatch we raise
+    :class:`OutputMismatchError` and mutate NOTHING (``prior_record`` is never
+    written to). Equal digests are accepted.
+    """
+    if recorded_digest != observed_digest:
+        raise OutputMismatchError(
+            "output_equality mismatch under "
+            f"{OUTPUT_EQUALITY_DEFAULT}: recorded={recorded_digest!r} "
+            f"observed={observed_digest!r}; reject_without_mutation"
+        )
+    return True

--- a/src/assetutilities/workflow_api/output_contract.py
+++ b/src/assetutilities/workflow_api/output_contract.py
@@ -1,0 +1,553 @@
+# ABOUTME: Curated-output + output-equality contract (workspace-hub#3431): curated
+# ABOUTME: taxonomy, digest_contribution, digest-of-sorted-digests equality, fail disjointness.
+"""Curated output records and the output-equality digest.
+
+This module implements the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``records.output`` +
+``identity.output_equality`` + ``failure_policy`` blocks. It OWNS the
+``output_equality_digest`` (which #3428 references while owning the
+``mismatch -> reject_without_mutation`` POLICY, reused verbatim here via
+:func:`identity.assert_output_equality`). It is stdlib-only (``hashlib``, ``re``
+plus :mod:`identity`), matching :mod:`envelope`, :mod:`identity`, :mod:`artifact`.
+
+Design invariants (from the approved+remediated #3431 plan):
+
+- **Curated-vs-excluded taxonomy is a declared allowlist.** ``primary_result``,
+  ``validation_evidence``, ``selected_report``, ``decision_support`` are the ONLY
+  curated labels. Anything unlabeled defaults to EXCLUDED (fail-closed) -- it is
+  never recorded and never digested (:func:`is_curated_label`,
+  :func:`make_output_record`).
+- **Output record is role-bearing; it references Artifacts by content_digest.**
+  It never redefines an artifact (that is :mod:`artifact`'s concern). Fields:
+  role, native_schema {id, version}, media_type, shape/row_count, per-field units,
+  coordinate/sign convention (when applicable), validation_state, review_state,
+  artifact_refs and ``digest_contribution``.
+- **digest_contribution DEFAULTS to ``included``.** ``excluded`` is permitted ONLY
+  via an explicitly declared + justified rule (fail-closed exactly like the semantic
+  canonicalizer). An undeclared / silent exclusion fails closed -- an unguarded
+  exclusion could silently drop a nondeterministic curated output so exact-rerun
+  equality passes while bytes differ (a masked reproducibility defect).
+- **output_equality_digest is a digest-of-sorted-digests.** default =
+  ``raw_bytes_sha256`` = ``sha256(identity.canonicalize(sorted list of the per-artifact
+  sha256 content_digests of every digest-eligible curated output))`` -- NOT raw byte
+  concatenation (which is boundary-ambiguous). A semantic canonicalizer is allowed
+  ONLY when all five fields (canonicalizer_id, canonicalizer_version, raw_hash,
+  semantic_hash, explicit_approval) are declared; undeclared normalization is
+  presentation_only. Exact-rerun mismatch fails publication and cannot overwrite the
+  prior record (:func:`assert_output_equality` delegates to identity's policy).
+- **Success vs failure requirement sets are provably disjoint.** A
+  ``failure_signature`` presence/absence is the XOR discriminator: ``succeeded`` MUST
+  NOT carry it; ``reproducible_failure`` MUST. Failure normalization requires
+  failure_phase, failure_code, failure_signature, curated_diagnostic_digests,
+  replay_evidence. The signature strips volatile paths/timestamps/pids/hosts and
+  normalizes stack frames by module ``qualname`` (drop file path + line, keep
+  module.func) so the same fault hashes identically cross-machine. Failed runs are
+  eligible only for run_health / diagnostics and FORBIDDEN from metric_observations
+  / insights / decision_briefs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from assetutilities.workflow_api import identity
+
+# ---- on-main contract constants -------------------------------------------
+DATASET_TABLE = "outputs"
+RESIDENCY = "hf_object_and_normalized_record"
+
+# Default output-equality comparison (shared with identity's reference).
+OUTPUT_EQUALITY_DEFAULT = identity.OUTPUT_EQUALITY_DEFAULT  # "raw_bytes_sha256"
+# The digest algorithm is versioned so a scheme change mints new equality digests.
+OUTPUT_EQUALITY_DIGEST_VERSION = "output-equality-1"
+
+# Declared curated allowlist. Anything else -> EXCLUDED (fail-closed, not recorded).
+CURATED_LABELS = frozenset(
+    {"primary_result", "validation_evidence", "selected_report", "decision_support"}
+)
+
+# digest_contribution domain.
+DIGEST_INCLUDED = "included"
+DIGEST_EXCLUDED = "excluded"
+
+# The five fields a declared semantic canonicalizer (equality exception) MUST carry.
+SEMANTIC_EXCEPTION_REQUIRED = (
+    "canonicalizer_id",
+    "canonicalizer_version",
+    "raw_hash",
+    "semantic_hash",
+    "explicit_approval",
+)
+
+# Failure normalization required set (verbatim from failure_policy.normalization_requires).
+FAILURE_NORMALIZATION_REQUIRED = (
+    "failure_phase",
+    "failure_code",
+    "failure_signature",
+    "curated_diagnostic_digests",
+    "replay_evidence",
+)
+
+# A failed run may only surface here; everything else is forbidden.
+FAILURE_ELIGIBLE_SURFACES = frozenset({"run_health", "diagnostics"})
+FAILURE_FORBIDDEN_SURFACES = frozenset(
+    {"metric_observations", "insights", "decision_briefs"}
+)
+
+# Terminal run statuses this contract reasons about.
+_SUCCEEDED = "succeeded"
+_REPRODUCIBLE_FAILURE = "reproducible_failure"
+
+FAILURE_SIGNATURE_VERSION = "fsig-1"
+
+
+class OutputContractError(ValueError):
+    """Raised when an output/report violates the curated-output contract."""
+
+
+# ---------------------------------------------------------------------------
+# curated taxonomy
+# ---------------------------------------------------------------------------
+
+def is_curated_label(label) -> bool:
+    """True iff ``label`` is a declared curated label; unlabeled -> ``False``.
+
+    An unlabeled or unknown output defaults to EXCLUDED (fail-closed): it is never
+    recorded and never contributes to the equality digest.
+    """
+    return label in CURATED_LABELS
+
+
+# ---------------------------------------------------------------------------
+# digest helpers
+# ---------------------------------------------------------------------------
+
+def _is_hex_sha256(value) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(c in "0123456789abcdef" for c in value)
+    )
+
+
+def _validate_artifact_refs(artifact_refs):
+    if not isinstance(artifact_refs, (list, tuple)) or not artifact_refs:
+        raise OutputContractError("artifact_refs must be a non-empty list")
+    normalized = []
+    for ref in artifact_refs:
+        if isinstance(ref, str):
+            content_digest = ref
+            ref = {"content_digest": content_digest}
+        elif isinstance(ref, dict):
+            content_digest = ref.get("content_digest")
+        else:
+            raise OutputContractError(
+                f"artifact_ref must be a dict or content_digest string, got {type(ref).__name__}"
+            )
+        if not _is_hex_sha256(content_digest):
+            raise OutputContractError(
+                f"artifact_ref.content_digest must be a 64-char hex sha256, got {content_digest!r}"
+            )
+        normalized.append(dict(ref))
+    return normalized
+
+
+def _validate_exclusion_rule(rule):
+    """A digest exclusion is permitted ONLY via a declared + justified rule."""
+    if not isinstance(rule, dict):
+        raise OutputContractError(
+            "digest_contribution 'excluded' requires a declared exclusion_rule dict "
+            "(fail-closed: an undeclared exclusion could mask a reproducibility defect)"
+        )
+    rule_id = rule.get("rule_id")
+    justification = rule.get("justification")
+    if not rule_id or not isinstance(rule_id, str):
+        raise OutputContractError("exclusion_rule requires a non-empty 'rule_id'")
+    if not justification or not isinstance(justification, str):
+        raise OutputContractError("exclusion_rule requires a non-empty 'justification'")
+    return {"rule_id": rule_id, "justification": justification}
+
+
+# ---------------------------------------------------------------------------
+# output record construction
+# ---------------------------------------------------------------------------
+
+def make_output_record(
+    *,
+    role,
+    native_schema,
+    media_type,
+    curated_label,
+    artifact_refs,
+    shape=None,
+    row_count=None,
+    units=None,
+    convention=None,
+    validation_state=None,
+    review_state=None,
+    digest_contribution=None,
+    exclusion_rule=None,
+) -> dict:
+    """Build a curated Output record referencing Artifacts by content_digest.
+
+    Fail-closed rules:
+
+    - ``curated_label`` MUST be in :data:`CURATED_LABELS`; an unlabeled / unknown
+      output is EXCLUDED and cannot be recorded.
+    - ``native_schema`` MUST carry an ``id`` + ``version``.
+    - ``digest_contribution`` DEFAULTS to ``included``; ``excluded`` is permitted
+      ONLY with a declared + justified ``exclusion_rule``.
+    - ``artifact_refs`` reference existing Artifacts by 64-hex ``content_digest``
+      (this module never redefines an artifact -- see :mod:`artifact`).
+    """
+    if not is_curated_label(curated_label):
+        raise OutputContractError(
+            f"output label {curated_label!r} is not curated (allowlist={sorted(CURATED_LABELS)}); "
+            "unlabeled outputs default to EXCLUDED and are never recorded/digested"
+        )
+    if not role:
+        raise OutputContractError("output record requires a non-empty role")
+    if not media_type:
+        raise OutputContractError("output record requires a media_type")
+    if not isinstance(native_schema, dict) or not native_schema.get("id") or not native_schema.get("version"):
+        raise OutputContractError("native_schema must be a dict carrying an 'id' and 'version'")
+
+    refs = _validate_artifact_refs(artifact_refs)
+
+    if digest_contribution is None:
+        digest_contribution = DIGEST_INCLUDED
+    if digest_contribution not in (DIGEST_INCLUDED, DIGEST_EXCLUDED):
+        raise OutputContractError(
+            f"digest_contribution must be 'included' or 'excluded', got {digest_contribution!r}"
+        )
+    resolved_rule = None
+    if digest_contribution == DIGEST_EXCLUDED:
+        resolved_rule = _validate_exclusion_rule(exclusion_rule)
+    elif exclusion_rule is not None:
+        raise OutputContractError(
+            "exclusion_rule only applies when digest_contribution == 'excluded'"
+        )
+
+    return {
+        "role": role,
+        "native_schema": dict(native_schema),
+        "media_type": media_type,
+        "curated_label": curated_label,
+        "shape": shape,
+        "row_count": row_count,
+        "units": dict(units) if isinstance(units, dict) else units,
+        "convention": convention,
+        "validation_state": validation_state,
+        "review_state": review_state,
+        "artifact_refs": refs,
+        "digest_contribution": digest_contribution,
+        "exclusion_rule": resolved_rule,
+    }
+
+
+def _is_digest_eligible(record) -> bool:
+    """A curated output contributes to the equality digest iff it is labelled
+    curated AND its ``digest_contribution`` is ``included``."""
+    if not isinstance(record, dict):
+        raise OutputContractError("output record must be a dict")
+    if not is_curated_label(record.get("curated_label")):
+        return False
+    return record.get("digest_contribution", DIGEST_INCLUDED) == DIGEST_INCLUDED
+
+
+# ---------------------------------------------------------------------------
+# native-schema validation
+# ---------------------------------------------------------------------------
+
+def _type_ok(spec: str, value) -> bool:
+    if spec == "any":
+        return True
+    if spec == "null":
+        return value is None
+    if spec == "boolean":
+        return isinstance(value, bool)
+    if spec == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if spec == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if spec == "string":
+        return isinstance(value, str)
+    if spec == "array":
+        return isinstance(value, (list, tuple))
+    if spec == "object":
+        return isinstance(value, dict)
+    raise OutputContractError(f"unknown native_schema field type {spec!r}")
+
+
+def assert_payload_conforms(native_schema, payload) -> bool:
+    """Reject a payload that violates its declared ``native_schema``.
+
+    The schema declares ``fields`` (name -> type) and optional ``required``. A
+    missing required field, a wrong-typed field, or an undeclared extra field all
+    fail closed (:class:`OutputContractError`). Returns ``True`` when conforming.
+    """
+    if not isinstance(native_schema, dict):
+        raise OutputContractError("native_schema must be a dict")
+    fields = native_schema.get("fields")
+    if not isinstance(fields, dict):
+        raise OutputContractError("native_schema must declare a 'fields' mapping to validate a payload")
+    if not isinstance(payload, dict):
+        raise OutputContractError("payload must be a dict")
+    required = native_schema.get("required", [])
+
+    for name in required:
+        if name not in payload:
+            raise OutputContractError(f"payload missing required field {name!r}")
+    extra = set(payload) - set(fields)
+    if extra:
+        raise OutputContractError(
+            f"payload has undeclared field(s) not in native_schema: {sorted(extra)}"
+        )
+    for name, value in payload.items():
+        spec = fields[name]
+        if not _type_ok(spec, value):
+            raise OutputContractError(
+                f"payload field {name!r}={value!r} violates declared type {spec!r}"
+            )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# output_equality_digest (owned here; policy owned by identity)
+# ---------------------------------------------------------------------------
+
+def _validate_semantic_declaration(decl) -> dict:
+    """A semantic canonicalizer is allowed ONLY when all five fields are declared."""
+    if not isinstance(decl, dict):
+        raise OutputContractError("semantic_canonicalizer declaration must be a dict")
+    missing = [k for k in SEMANTIC_EXCEPTION_REQUIRED if not decl.get(k)]
+    if missing:
+        raise OutputContractError(
+            "semantic canonicalizer fails closed; declaration missing required fields: "
+            f"{missing} (required={list(SEMANTIC_EXCEPTION_REQUIRED)})"
+        )
+    return decl
+
+
+def output_equality_digest(outputs, *, semantic_canonicalizer=None) -> dict:
+    """Compute the versioned ``output_equality_digest`` over curated outputs.
+
+    Default (``raw_bytes_sha256``) = ``sha256(identity.canonicalize(sorted list of
+    the per-artifact sha256 content_digests of every digest-eligible curated
+    output))`` -- a digest-of-sorted-digests, boundary-safe (NOT raw concatenation).
+    Only outputs that are curated AND ``digest_contribution == included`` are counted.
+
+    A semantic canonicalizer is honoured ONLY when fully declared (the five
+    :data:`SEMANTIC_EXCEPTION_REQUIRED` fields); its ``semantic_hash`` becomes the
+    digest. Undeclared normalization is presentation_only and never alters equality.
+    Returns ``{"algorithm", "version", "digest", "input_digest_count"}``.
+    """
+    if semantic_canonicalizer is not None:
+        decl = _validate_semantic_declaration(semantic_canonicalizer)
+        return {
+            "algorithm": f"semantic:{decl['canonicalizer_id']}@{decl['canonicalizer_version']}",
+            "version": OUTPUT_EQUALITY_DIGEST_VERSION,
+            "digest": decl["semantic_hash"],
+            "raw_hash": decl["raw_hash"],
+            "explicit_approval": decl["explicit_approval"],
+        }
+
+    content_digests = []
+    for record in outputs:
+        if not _is_digest_eligible(record):
+            continue
+        for ref in record["artifact_refs"]:
+            content_digests.append(ref["content_digest"])
+    ordered = sorted(content_digests)
+    digest = hashlib.sha256(identity.canonicalize(ordered).encode("utf-8")).hexdigest()
+    return {
+        "algorithm": OUTPUT_EQUALITY_DEFAULT,
+        "version": OUTPUT_EQUALITY_DIGEST_VERSION,
+        "digest": digest,
+        "input_digest_count": len(ordered),
+    }
+
+
+def assert_output_equality(recorded_digest, observed_digest, *, prior_record=None) -> bool:
+    """Enforce the exact-rerun equality policy (owned by :mod:`identity`).
+
+    Delegates to :func:`identity.assert_output_equality`: an exact-rerun mismatch
+    raises :class:`identity.OutputMismatchError` and mutates NOTHING
+    (``reject_without_mutation``); equal digests are accepted.
+    """
+    return identity.assert_output_equality(
+        recorded_digest, observed_digest, prior_record=prior_record
+    )
+
+
+# ---------------------------------------------------------------------------
+# success vs failure: provably disjoint via the failure_signature XOR
+# ---------------------------------------------------------------------------
+
+def make_failure_normalization(
+    *,
+    failure_phase,
+    failure_code,
+    failure_signature,
+    curated_diagnostic_digests,
+    replay_evidence,
+) -> dict:
+    """Build a reproducible-failure normalization record (all five fields required)."""
+    record = {
+        "failure_phase": failure_phase,
+        "failure_code": failure_code,
+        "failure_signature": failure_signature,
+        "curated_diagnostic_digests": curated_diagnostic_digests,
+        "replay_evidence": replay_evidence,
+    }
+    missing = [k for k in FAILURE_NORMALIZATION_REQUIRED if not record.get(k)]
+    if missing:
+        raise OutputContractError(
+            f"failure normalization missing required fields: {missing}"
+        )
+    return record
+
+
+def assert_status_requirements(status, record) -> bool:
+    """Enforce that success/failure requirement sets are disjoint via the signature.
+
+    ``failure_signature`` is the XOR discriminator: a ``succeeded`` record MUST NOT
+    carry one; a ``reproducible_failure`` record MUST carry one AND the full
+    normalization set. Raises :class:`OutputContractError` on violation.
+    """
+    if not isinstance(record, dict):
+        raise OutputContractError("run record must be a dict")
+    has_signature = bool(record.get("failure_signature"))
+    if status == _SUCCEEDED:
+        if has_signature:
+            raise OutputContractError(
+                "a succeeded run MUST NOT carry a failure_signature (disjointness violated)"
+            )
+        return True
+    if status == _REPRODUCIBLE_FAILURE:
+        if not has_signature:
+            raise OutputContractError(
+                "a reproducible_failure run MUST carry a failure_signature (XOR discriminator)"
+            )
+        missing = [k for k in FAILURE_NORMALIZATION_REQUIRED if not record.get(k)]
+        if missing:
+            raise OutputContractError(
+                f"reproducible_failure missing required normalization fields: {missing}"
+            )
+        return True
+    raise OutputContractError(f"unknown / non-terminal status for surfacing: {status!r}")
+
+
+# ---------------------------------------------------------------------------
+# failure_signature: stable cross-machine
+# ---------------------------------------------------------------------------
+
+# Volatile substrings to strip before hashing so the same fault hashes identically
+# on any machine: absolute paths, ISO/space timestamps, pids, hostnames.
+_VOL_TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?")
+_VOL_PID = re.compile(r"\bpid[=: ]\s*\d+", re.IGNORECASE)
+_VOL_HOST = re.compile(r"\bhost[=: ]\s*\S+", re.IGNORECASE)
+_VOL_WIN_PATH = re.compile(r"[A-Za-z]:\\[^\s'\"]+")
+_VOL_UNIX_PATH = re.compile(r"(?:/[\w.\-]+)+/?")
+
+# Markers after which the remainder of a file path is an importable module path.
+_MODULE_ROOT_MARKERS = ("site-packages/", "dist-packages/")
+_STDLIB_RE = re.compile(r"/lib/python\d+\.\d+/")
+
+
+def _strip_volatile(text: str) -> str:
+    if not text:
+        return ""
+    text = _VOL_TIMESTAMP.sub("<ts>", text)
+    text = _VOL_PID.sub("pid=<pid>", text)
+    text = _VOL_HOST.sub("host=<host>", text)
+    text = _VOL_WIN_PATH.sub("<path>", text)
+    text = _VOL_UNIX_PATH.sub("<path>", text)
+    return text
+
+
+def _module_from_file(path: str) -> str:
+    """Derive an importable module qualname from a (machine-varying) file path.
+
+    Drops everything up to and including the venv/stdlib root marker, then converts
+    the remaining ``pkg/sub/mod.py`` tail into ``pkg.sub.mod``. This makes a
+    third-party/stdlib/venv frame identical across machines (path + line dropped).
+    """
+    tail = path
+    for marker in _MODULE_ROOT_MARKERS:
+        idx = path.rfind(marker)
+        if idx != -1:
+            tail = path[idx + len(marker):]
+            break
+    else:
+        m = _STDLIB_RE.search(path)
+        if m:
+            tail = path[m.end():]
+        else:
+            # project frame: keep only the basename component chain we can see;
+            # fall back to the file's own name (still line/path-free).
+            tail = path.rsplit("/", 1)[-1]
+    if tail.endswith(".py"):
+        tail = tail[:-3]
+    return tail.strip("/").replace("/", ".")
+
+
+def _normalize_frame(frame) -> str:
+    """Reduce a stack frame to ``module.func`` (drop file path + line number)."""
+    if not isinstance(frame, dict):
+        raise OutputContractError("each frame must be a dict")
+    func = frame.get("func") or frame.get("name") or "<unknown>"
+    module = frame.get("module")
+    if not module:
+        file_path = frame.get("file") or frame.get("filename")
+        if not file_path:
+            raise OutputContractError("frame needs a 'module' or 'file' to normalize")
+        module = _module_from_file(file_path)
+    return f"{module}.{func}"
+
+
+def failure_signature(*, phase, code, frames=(), detail="") -> str:
+    """Compute a stable, cross-machine failure signature.
+
+    Strips volatile paths/timestamps/pids/hosts from ``detail`` and normalizes each
+    stack frame to its module ``qualname`` (``module.func``, dropping file path and
+    line number) so the same fault hashes identically on any machine. The result is
+    versioned (``fsig-1:<hex>``).
+    """
+    normalized_frames = [_normalize_frame(f) for f in frames]
+    payload = {
+        "phase": phase,
+        "code": code,
+        "frames": normalized_frames,
+        "detail": _strip_volatile(detail),
+    }
+    digest = hashlib.sha256(identity.canonicalize(payload).encode("utf-8")).hexdigest()
+    return f"{FAILURE_SIGNATURE_VERSION}:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# surface eligibility for failed runs
+# ---------------------------------------------------------------------------
+
+def assert_surface_allowed(status, surface) -> bool:
+    """Reject a failed run published to a forbidden surface (fail-closed).
+
+    A ``reproducible_failure`` may surface only in run_health / diagnostics; it is
+    FORBIDDEN from metric_observations / insights / decision_briefs (and any unknown
+    surface fails closed). A ``succeeded`` run may surface anywhere.
+    """
+    if status == _SUCCEEDED:
+        return True
+    if status == _REPRODUCIBLE_FAILURE:
+        if surface in FAILURE_ELIGIBLE_SURFACES:
+            return True
+        if surface in FAILURE_FORBIDDEN_SURFACES:
+            raise OutputContractError(
+                f"a failed run is forbidden from the {surface!r} surface "
+                f"(eligible only for {sorted(FAILURE_ELIGIBLE_SURFACES)})"
+            )
+        raise OutputContractError(
+            f"a failed run may not surface on the unknown surface {surface!r} (fail-closed)"
+        )
+    raise OutputContractError(f"unknown / non-terminal status: {status!r}")

--- a/src/assetutilities/workflow_api/report.py
+++ b/src/assetutilities/workflow_api/report.py
@@ -1,0 +1,177 @@
+# ABOUTME: Rolling per-algorithm report renderer (workspace-hub#3431): mandatory
+# ABOUTME: Inputs/Outputs, failed-run separation, exact-HF-revision pinning, ledger eligibility.
+"""Rolling algorithm report (one per algorithm).
+
+Renders a single HTML report per algorithm summarizing its latest + historical
+runs. Implements the #3431 report contract:
+
+- **Mandatory Inputs + Outputs sections**, plus ONLY the optional sections a run
+  actually declares (no empty optional scaffolding).
+- **Failed runs are clearly separated** from succeeded runs.
+- **Every displayed run links to an EXACT Hugging Face revision.** A finalized
+  (``pinned``) report REJECTS a moving ref (``main``, ``HEAD``, a branch/tag, a
+  short sha); a ``main``/moving ref fails. A draft (unpinned) report tolerates a
+  not-yet-pinned revision and is banner-marked ``DRAFT``. This matches the #3433
+  Gate B/D lifecycle: drafted UNPINNED, finalized PINNED to an exact revision.
+- **Eligibility comes from a SOURCE-REPO ledger** (``publications.jsonl``), NOT
+  Hugging Face visibility. A run is displayed iff it is published in the ledger; a
+  run's HF ``visible`` flag is deliberately ignored.
+- **Output is HTML-safe**: every interpolated value is escaped, so injected markup
+  (e.g. ``<script>``) can never survive into the rendered page.
+
+Stdlib-only (``html``, ``re``) plus :mod:`output_contract` for its error type.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+from assetutilities.workflow_api.output_contract import OutputContractError
+
+# A run's terminal statuses this report distinguishes.
+_SUCCEEDED = "succeeded"
+_REPRODUCIBLE_FAILURE = "reproducible_failure"
+
+# Mandatory sections always rendered for every displayed run.
+MANDATORY_SECTIONS = ("inputs", "outputs")
+
+# An EXACT git/HF revision: a full 40-char lowercase hex commit sha. A moving ref
+# (branch/tag/HEAD/short sha) is NOT exact and fails a finalized report.
+_EXACT_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def is_exact_revision(revision) -> bool:
+    """True iff ``revision`` is an exact (full 40-hex) commit sha.
+
+    A moving ref -- ``main``, ``HEAD``, ``refs/heads/*``, a tag like ``v1.0.0``, or a
+    truncated sha -- is NOT exact and returns ``False``.
+    """
+    return isinstance(revision, str) and bool(_EXACT_REVISION_RE.match(revision))
+
+
+def eligible_run_ids(ledger) -> set:
+    """Return the set of published run_ids from a source-repo ``publications.jsonl``.
+
+    ``ledger`` is a list of entries (dicts). An entry makes its run eligible when it
+    is published (``published`` truthy, or ``state == "published"``). This is the
+    SOLE source of display eligibility -- Hugging Face visibility is never consulted.
+    """
+    published = set()
+    for entry in ledger or ():
+        if not isinstance(entry, dict):
+            raise OutputContractError("each ledger entry must be a dict")
+        run_id = entry.get("run_id")
+        if not run_id:
+            continue
+        if entry.get("published") or entry.get("state") == "published":
+            published.add(run_id)
+    return published
+
+
+def _esc(value) -> str:
+    """HTML-escape any interpolated value (never trust caller-supplied text)."""
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _render_kv_section(title, items) -> str:
+    rows = []
+    for item in items or ():
+        name = _esc(item.get("name") if isinstance(item, dict) else item)
+        value = _esc(item.get("value") if isinstance(item, dict) else "")
+        rows.append(f"<li><span class='k'>{name}</span>: <span class='v'>{value}</span></li>")
+    body = "\n".join(rows) if rows else "<li class='empty'>(none)</li>"
+    return f"<section class='{_esc(title.lower())}'><h4>{_esc(title)}</h4><ul>{body}</ul></section>"
+
+
+def _render_optional_sections(optional) -> str:
+    """Render ONLY the optional sections a run actually declares (non-empty)."""
+    if not optional:
+        return ""
+    parts = []
+    for name, content in optional.items():
+        if content in (None, "", [], {}):
+            continue  # only-applicable: skip empty optional sections
+        parts.append(
+            f"<section class='optional optional-{_esc(name)}'>"
+            f"<h4>{_esc(name)}</h4><div class='v'>{_esc(content)}</div></section>"
+        )
+    return "\n".join(parts)
+
+
+def _render_run(run, *, pinned, latest) -> str:
+    run_id = _esc(run.get("run_id"))
+    status = run.get("status")
+    revision = run.get("hf_revision")
+
+    if pinned and not is_exact_revision(revision):
+        raise OutputContractError(
+            f"finalized (pinned) report requires an EXACT HF revision for run "
+            f"{run.get('run_id')!r}; a moving ref {revision!r} fails"
+        )
+
+    is_failed = status == _REPRODUCIBLE_FAILURE
+    css = "run failed-run" if is_failed else "run succeeded-run"
+    if latest:
+        css += " latest"
+    status_label = _esc(status)
+    rev_label = _esc(revision) if revision else "(unpinned)"
+    rev_html = (
+        f"<a class='hf-revision' href='hf://revision/{rev_label}'>{rev_label}</a>"
+        if revision else "<span class='hf-revision unpinned'>(unpinned)</span>"
+    )
+
+    inputs = _render_kv_section("Inputs", run.get("inputs"))
+    outputs = _render_kv_section("Outputs", run.get("outputs"))
+    optional = _render_optional_sections(run.get("optional"))
+    return (
+        f"<article class='{css}' data-run-id='{run_id}'>"
+        f"<header><h3>Run {run_id}</h3>"
+        f"<span class='status'>{status_label}</span> "
+        f"<span class='revision'>{rev_html}</span></header>"
+        f"{inputs}{outputs}{optional}</article>"
+    )
+
+
+def render_report(*, algorithm, runs, ledger, pinned=False, title=None) -> str:
+    """Render the rolling HTML report for one algorithm.
+
+    ``runs`` is ordered latest-first. Only runs published in the source-repo
+    ``ledger`` are displayed (HF visibility ignored). Failed runs are separated into
+    their own section. When ``pinned`` (finalized), every displayed run MUST link to
+    an EXACT HF revision or :class:`OutputContractError` is raised; otherwise the
+    report is banner-marked ``DRAFT (unpinned)``.
+    """
+    eligible = eligible_run_ids(ledger)
+    displayed = [r for r in (runs or ()) if r.get("run_id") in eligible]
+
+    succeeded, failed = [], []
+    first = True
+    for run in displayed:
+        rendered = _render_run(run, pinned=pinned, latest=first)
+        first = False
+        if run.get("status") == _REPRODUCIBLE_FAILURE:
+            failed.append(rendered)
+        else:
+            succeeded.append(rendered)
+
+    banner = "FINAL (pinned)" if pinned else "DRAFT (unpinned)"
+    heading = _esc(title or f"Rolling report: {algorithm}")
+
+    succeeded_html = (
+        "<section class='successful-runs'><h2>Successful runs (latest first)</h2>"
+        + ("\n".join(succeeded) if succeeded else "<p class='empty'>(no successful runs)</p>")
+        + "</section>"
+    )
+    failed_html = (
+        "<section class='failed-runs'><h2>Failed runs (separated)</h2>"
+        + ("\n".join(failed) if failed else "<p class='empty'>(no failed runs)</p>")
+        + "</section>"
+    )
+
+    return (
+        f"<main class='algorithm-report' data-algorithm='{_esc(algorithm)}'>"
+        f"<header><h1>{heading}</h1>"
+        f"<div class='lifecycle-banner'>{_esc(banner)}</div></header>"
+        f"{succeeded_html}{failed_html}</main>"
+    )

--- a/tests/workflow_api/test_artifact.py
+++ b/tests/workflow_api/test_artifact.py
@@ -318,3 +318,16 @@ def test_eligibility_is_byte_license_times_reference_role():
     assert "eligible" not in public_art and "class" not in public_art
     assert artifact.RESIDENCY_CONTRACT == "content_addressed_hf_object_or_explicit_exclusion"
     assert artifact.DATASET_TABLE == "artifacts"
+
+
+def test_structured_content_digest_is_plain_hash_of_stored_bytes():
+    # A content_digest is a CONTENT ADDRESS: it must equal a plain sha256 of the
+    # exact bytes the object store persists, so workspace-hub#3433's uniform
+    # object-store re-hash can revalidate a structured artifact without knowing
+    # its type. Domain separation (an identity concern) must NOT leak in here.
+    obj = {"b": 2, "a": 1}
+    stored = artifact.structured_stored_bytes(obj)
+    assert artifact.structured_object_digest(obj) == hashlib.sha256(stored).hexdigest()
+    # and it round-trips through verify_integrity as a physical re-hash of stored bytes
+    rec = artifact.structured_artifact(obj, media_type="application/json", native_format="jcs")
+    assert artifact.verify_integrity(rec, stored_bytes=stored) is True

--- a/tests/workflow_api/test_artifact.py
+++ b/tests/workflow_api/test_artifact.py
@@ -1,0 +1,320 @@
+# ABOUTME: TDD tests for the content-addressed artifact + HF-residency contract
+# ABOUTME: (workspace-hub#3429): physical-byte vs structured digests, role-free identity,
+# ABOUTME: integrity-from-bytes, storage-locator safety, and projection-time residency.
+"""Artifact contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``artifact`` record
+(``identity: content_digest``, ``residency:
+content_addressed_hf_object_or_explicit_exclusion``, ``dataset_table: artifacts``):
+
+- content_digest is SHA-256 of the EXACT STORED bytes (physical) or of the
+  ``identity.canonicalize`` JCS form (structured object). Compression is purely
+  descriptive metadata and NEVER triggers decode-before-hash.
+- The Artifact record is role-free / byte-intrinsic: identical bytes -> one record
+  regardless of how many runs/roles reference it. Residency ``class``/role/
+  ``eligible`` never live on the record.
+- Integrity is re-validated from the object's actual bytes; a manifest-asserted
+  digest that disagrees is rejected (bytes win, manifest is untrusted).
+- storage_locator must be shard-sharded + tied to the record digest and reject
+  path-leaking locators.
+- Residency eligibility is computed at projection time as (byte-intrinsic license
+  evidence) x (per-reference role); a dataset-level license can never grant rights
+  absent from the artifact's own ``license_evidence_ref``. Excluded roles get a
+  VISIBLE ``class: excluded`` marker, never silent omission.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+
+import pytest
+
+from assetutilities.workflow_api import artifact, identity
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _sha256(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def _public_license() -> dict:
+    return {"redistribution": "public", "license": "CC-BY-4.0"}
+
+
+# ---------------------------------------------------------------------------
+# 1. physical artifact hashes the stored bytes, never the decoded bytes
+# ---------------------------------------------------------------------------
+
+def test_physical_artifact_hashes_stored_bytes_not_decoded():
+    decoded = b"replay-critical payload" * 64
+    stored = gzip.compress(decoded)
+    assert stored != decoded
+
+    art = artifact.physical_artifact(
+        stored, media_type="application/octet-stream",
+        native_format="ndjson", compression="gzip",
+    )
+
+    # TRUE content addressing: digest is over the exact immutable STORED bytes.
+    assert art["content_digest"] == _sha256(stored)
+    assert art["size_bytes"] == len(stored)
+    # compression is PURELY DESCRIPTIVE metadata; it must NOT decode-before-hash.
+    assert art["compression"] == "gzip"
+    assert art["content_digest"] != _sha256(decoded)
+
+    # a publisher re-hashing the exact stored bytes agrees.
+    assert artifact.verify_integrity(art, stored_bytes=stored) is True
+    # re-hashing the DECODED bytes must NOT be accepted as the same object.
+    with pytest.raises(artifact.IntegrityError):
+        artifact.verify_integrity(art, stored_bytes=decoded)
+
+
+# ---------------------------------------------------------------------------
+# 2. structured object uses the canonical (JCS) form
+# ---------------------------------------------------------------------------
+
+def test_structured_object_uses_canonical_form():
+    obj_a = {"b": 1, "a": {"y": 2, "x": 3}}
+    obj_b = {"a": {"x": 3, "y": 2}, "b": 1}  # different key ordering, same object
+
+    d_a = artifact.structured_object_digest(obj_a)
+    d_b = artifact.structured_object_digest(obj_b)
+    assert d_a == d_b, "two key-orderings of one object must yield one digest"
+
+    # digest is derived through identity.canonicalize (the JCS owner), not raw dict repr.
+    assert identity.canonicalize(obj_a) == identity.canonicalize(obj_b)
+
+    art_a = artifact.structured_artifact(obj_a)
+    art_b = artifact.structured_artifact(obj_b)
+    assert art_a["content_digest"] == art_b["content_digest"] == d_a
+    assert art_a == art_b  # one artifact record regardless of key order
+
+
+# ---------------------------------------------------------------------------
+# 3. identical bytes -> ONE artifact record, no role/residency on the record
+# ---------------------------------------------------------------------------
+
+def test_identical_bytes_one_artifact_record_across_roles():
+    payload = b"shared immutable object bytes"
+    art_seen_as_input = artifact.physical_artifact(
+        payload, media_type="text/csv", native_format="csv")
+    art_seen_as_output = artifact.physical_artifact(
+        payload, media_type="text/csv", native_format="csv")
+
+    # identical bytes -> identical record (deduplicated to one content_digest).
+    assert art_seen_as_input == art_seen_as_output
+    assert art_seen_as_input["content_digest"] == _sha256(payload)
+
+    # the record carries ONLY byte-intrinsic fields; role/residency live elsewhere.
+    for banned in ("class", "role", "eligible", "residency", "residency_class"):
+        assert banned not in art_seen_as_input
+    assert set(art_seen_as_input) == {
+        "content_digest", "size_bytes", "media_type", "native_format",
+        "compression", "schema_ref", "storage_locator", "license_evidence_ref",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. integrity is revalidated from the bytes; a manifest lie is rejected
+# ---------------------------------------------------------------------------
+
+def test_integrity_revalidated_from_bytes_rejects_manifest_lie():
+    payload = b"authentic bytes"
+    art = artifact.physical_artifact(
+        payload, media_type="application/octet-stream", native_format="bin")
+
+    # (a) tampered bytes: the stored bytes changed, the asserted digest no longer holds.
+    with pytest.raises(artifact.IntegrityError):
+        artifact.verify_integrity(art, stored_bytes=b"tampered bytes")
+
+    # (b) a wrong manifest-asserted digest is rejected even for the genuine bytes:
+    # bytes win, the manifest is untrusted.
+    lying = dict(art)
+    lying["content_digest"] = "0" * 64
+    lying["storage_locator"] = artifact.storage_locator_for("0" * 64)
+    with pytest.raises(artifact.IntegrityError):
+        artifact.verify_integrity(lying, stored_bytes=payload)
+
+
+# ---------------------------------------------------------------------------
+# 5. storage_locator must equal objects/<d[:2]>/<d> for the record's own digest
+# ---------------------------------------------------------------------------
+
+def test_storage_locator_matches_record_digest():
+    payload = b"locator bytes"
+    art = artifact.physical_artifact(
+        payload, media_type="application/octet-stream", native_format="bin")
+    d = art["content_digest"]
+    assert art["storage_locator"] == "objects/" + d[:2] + "/" + d
+    assert artifact.validate_storage_locator(art["storage_locator"], d) is True
+
+    # a locator that points at a DIFFERENT digest is rejected.
+    other = "f" * 64
+    with pytest.raises(artifact.StorageLocatorError):
+        artifact.validate_storage_locator("objects/" + other[:2] + "/" + other, d)
+    # right digest but wrong shard prefix is rejected.
+    with pytest.raises(artifact.StorageLocatorError):
+        artifact.validate_storage_locator("objects/zz/" + d, d)
+    # constructing a record with a mismatched supplied locator is rejected.
+    with pytest.raises(artifact.StorageLocatorError):
+        artifact.make_artifact(
+            content_digest=d, size_bytes=len(payload), media_type="x",
+            native_format="bin", storage_locator="objects/00/" + other)
+
+
+# ---------------------------------------------------------------------------
+# 6. unsafe storage locators (absolute / ~ / UNC / ..) are rejected
+# ---------------------------------------------------------------------------
+
+def test_unsafe_storage_locator_rejected():
+    d = _sha256(b"whatever")
+    unsafe = [
+        "/etc/passwd",                       # absolute
+        "/objects/" + d[:2] + "/" + d,       # absolute even if otherwise shaped
+        "~/objects/" + d[:2] + "/" + d,      # home
+        "~root/secret",                      # home
+        "\\\\server\\share\\" + d,           # UNC
+        "C:\\objects\\" + d,                 # windows drive / backslash
+        "objects/../" + d[:2] + "/" + d,     # parent traversal
+        "objects/" + d[:2] + "/../" + d,     # parent traversal
+    ]
+    for loc in unsafe:
+        with pytest.raises(artifact.StorageLocatorError):
+            artifact.validate_storage_locator(loc, d)
+
+
+# ---------------------------------------------------------------------------
+# 7. restricted / ambiguous / client-specific / path-leak / non-redist FAIL
+# ---------------------------------------------------------------------------
+
+def test_restricted_ambiguous_client_pathleak_nonredist_fail_projection():
+    payload = b"sensitive object"
+    role = "curated_native_output"  # an otherwise HF-eligible role
+
+    failing_licenses = {
+        "restricted": {"redistribution": "restricted", "license": "MIT"},
+        "ambiguous": {"redistribution": "public", "license": "ambiguous"},
+        "client_specific": {"redistribution": "client_specific", "license": "MIT"},
+        "path_leak": {"redistribution": "public", "license": "MIT",
+                       "evidence_path": "/home/vamsee/client/LICENSE.txt"},
+        "non_redistributable": {"redistribution": "non_redistributable", "license": "MIT"},
+    }
+    for label, lic in failing_licenses.items():
+        art = artifact.physical_artifact(
+            payload, media_type="text/plain", native_format="txt",
+            license_evidence_ref=lic)
+        proj = artifact.project_reference_residency(art, role)
+        assert proj["class"] == artifact.CLASS_EXCLUDED, f"{label} must fail projection"
+        assert proj["reason"], "an excluded projection must carry a visible reason"
+
+
+# ---------------------------------------------------------------------------
+# 8. transient/cache/regenerable roles are VISIBLY excluded, not silently dropped
+# ---------------------------------------------------------------------------
+
+def test_excluded_roles_are_visibly_excluded():
+    payload = b"regenerable dump"
+    # a perfectly public license does NOT rescue a transient/regenerable role.
+    art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="log",
+        license_evidence_ref=_public_license())
+
+    for role in ("transient_log", "cache", "large_regenerable_dump"):
+        proj = artifact.project_reference_residency(art, role)
+        assert proj is not None, "exclusion must be an explicit marker, not silent omission"
+        assert proj["class"] == artifact.CLASS_EXCLUDED
+        assert role in proj["reason"]
+        assert proj["content_digest"] == art["content_digest"]
+
+
+# ---------------------------------------------------------------------------
+# 9. a dataset-level license can NOT grant rights the artifact itself lacks
+# ---------------------------------------------------------------------------
+
+def test_dataset_license_cannot_grant_missing_rights():
+    payload = b"no license evidence on this object"
+    art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="txt",
+        license_evidence_ref=None)  # NO byte-intrinsic license evidence
+
+    dataset_license = {"redistribution": "public", "license": "CC-BY-4.0"}
+    proj = artifact.project_reference_residency(
+        art, "curated_native_output", dataset_license=dataset_license)
+    assert proj["class"] == artifact.CLASS_EXCLUDED, (
+        "a dataset-level license must never grant rights absent from the "
+        "artifact's own license_evidence_ref")
+
+
+# ---------------------------------------------------------------------------
+# 10. an input reference and an output reference share ONE artifact, no dup
+# ---------------------------------------------------------------------------
+
+def test_input_and_output_reference_same_artifact_without_duplication():
+    obj = {"grid": [1, 2, 3], "coeff": 0.5}
+    art = artifact.structured_artifact(obj, license_evidence_ref=_public_license())
+
+    # referenced as a replay-critical input in run A and a curated output in run B:
+    # both point at the SAME content_digest; the record is identical (no role on it).
+    as_input = artifact.project_reference_residency(art, "replay_critical_input")
+    as_output = artifact.project_reference_residency(art, "curated_native_output")
+    assert as_input["content_digest"] == as_output["content_digest"] == art["content_digest"]
+    assert as_input["class"] == as_output["class"] == artifact.CLASS_HF_OBJECT
+    # the artifact record itself is unchanged by projection (role lives on the reference).
+    assert "role" not in art and "class" not in art
+
+
+# ---------------------------------------------------------------------------
+# 11. a dedicated forbidden-residency fixture is rejected at construction
+# ---------------------------------------------------------------------------
+
+def test_forbidden_residency_fixture_rejected():
+    payload = b"attempt to stamp residency onto the record"
+    d = _sha256(payload)
+    # stamping residency/role/eligibility onto the byte-intrinsic record is forbidden.
+    for forbidden_field in ("residency", "class", "role", "eligible"):
+        with pytest.raises(artifact.ArtifactError):
+            artifact.make_artifact(
+                content_digest=d, size_bytes=len(payload), media_type="x",
+                native_format="bin", **{forbidden_field: "excluded"})
+
+    # a fixture whose license is explicitly a forbidden residency also fails projection.
+    art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="txt",
+        license_evidence_ref={"redistribution": "forbidden", "license": "MIT"})
+    proj = artifact.project_reference_residency(art, "curated_native_output")
+    assert proj["class"] == artifact.CLASS_EXCLUDED
+
+
+# ---------------------------------------------------------------------------
+# 12. eligibility == (byte-license) x (reference-role), computed at projection
+# ---------------------------------------------------------------------------
+
+def test_eligibility_is_byte_license_times_reference_role():
+    payload = b"one object, many references"
+
+    public_art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="txt",
+        license_evidence_ref=_public_license())
+    restricted_art = artifact.physical_artifact(
+        payload + b"x", media_type="text/plain", native_format="txt",
+        license_evidence_ref={"redistribution": "restricted", "license": "MIT"})
+
+    # public license x eligible role -> HF object
+    assert artifact.project_reference_residency(
+        public_art, "curated_native_output")["class"] == artifact.CLASS_HF_OBJECT
+    # public license x excluded role -> excluded (role gate)
+    assert artifact.project_reference_residency(
+        public_art, "cache")["class"] == artifact.CLASS_EXCLUDED
+    # restricted license x eligible role -> excluded (license gate)
+    assert artifact.project_reference_residency(
+        restricted_art, "curated_native_output")["class"] == artifact.CLASS_EXCLUDED
+
+    # the product is computed at projection time, NOT stamped on the record.
+    assert "eligible" not in public_art and "class" not in public_art
+    assert artifact.RESIDENCY_CONTRACT == "content_addressed_hf_object_or_explicit_exclusion"
+    assert artifact.DATASET_TABLE == "artifacts"

--- a/tests/workflow_api/test_identity.py
+++ b/tests/workflow_api/test_identity.py
@@ -1,0 +1,411 @@
+# ABOUTME: TDD tests for the deterministic run-identity contract (workspace-hub#3428):
+# ABOUTME: canonical serialization, domain-separated digests, and identity derivation.
+"""Identity contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``identity`` block:
+canonical serialization owned here, SHA-256 digests domain-separated by id type,
+each id binds exactly its declared required components (and rejects the forbidden
+ones), and identity is fail-closed / re-derivable from a verified clean context.
+"""
+
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+
+import pytest
+
+from assetutilities.workflow_api import identity
+
+
+# ---------------------------------------------------------------------------
+# shared fixtures / builders
+# ---------------------------------------------------------------------------
+
+def _avid(**overrides) -> str:
+    kwargs = dict(
+        algorithm_id="stress_screen",
+        semantic_version="1.4.2",
+        clean_git_commit="a" * 40,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-" + "b" * 8,
+    )
+    kwargs.update(overrides)
+    return identity.algorithm_version_id(**kwargs)
+
+
+def _input_record(**overrides) -> dict:
+    rec = dict(
+        role="primary",
+        native_schema_version="ns-1",
+        source_snapshot="snap-2026-07-01",
+        transformation_id="xf-9",
+        artifact_sha256="c" * 64,
+        redistribution_rights="internal",
+        complete_replay_location="s3://bucket/replay/1",
+    )
+    rec.update(overrides)
+    return rec
+
+
+def _derive(**overrides):
+    kwargs = dict(
+        algorithm_id="stress_screen",
+        semantic_version="1.4.2",
+        clean_git_commit="a" * 40,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-" + "b" * 8,
+        inputs=[("primary", "irid-1"), ("aux", "irid-2")],
+        execution_parameters={"tolerance": "1e-6", "mode": "fast"},
+        seed=1234,
+    )
+    kwargs.update(overrides)
+    return identity.derive_run_identity(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. algorithm_version_id binds all required components
+# ---------------------------------------------------------------------------
+
+def test_algorithm_version_id_binds_all_components():
+    base = _avid()
+    changes = {
+        "algorithm_id": "other_algo",
+        "semantic_version": "1.4.3",
+        "clean_git_commit": "d" * 40,
+        "input_schema_version": "in-4",
+        "output_schema_version": "out-3",
+        "environment_digest": "env-" + "e" * 8,
+    }
+    ids = {base}
+    for comp, newval in changes.items():
+        variant = _avid(**{comp: newval})
+        assert variant != base, f"changing {comp} must change algorithm_version_id"
+        ids.add(variant)
+    # every single-component change produced a distinct id
+    assert len(ids) == len(changes) + 1
+
+    # a missing/None required component is rejected (fail-closed), never hashed as absent
+    with pytest.raises(identity.IdentityError):
+        _avid(environment_digest=None)
+
+
+# ---------------------------------------------------------------------------
+# 2. run_id binds its components, excludes outputs, uses input_set_id
+# ---------------------------------------------------------------------------
+
+def test_run_id_binds_components_excludes_outputs():
+    avid = _avid()
+    isid = identity.input_set_id([("primary", "irid-1")])
+    rid = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters={"mode": "fast"},
+        seed=7,
+    )
+    # run_id has no output channel at all -> an output change cannot move it.
+    rid_again = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters={"mode": "fast"},
+        seed=7,
+    )
+    assert rid == rid_again
+
+    # each real component is bound
+    assert rid != identity.run_id(
+        algorithm_version_id=_avid(algorithm_id="x"),
+        input_set_id=isid, execution_parameters={"mode": "fast"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=identity.input_set_id([("primary", "irid-2")]),
+        execution_parameters={"mode": "fast"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid, input_set_id=isid,
+        execution_parameters={"mode": "slow"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid, input_set_id=isid,
+        execution_parameters={"mode": "fast"}, seed=8)
+
+
+# ---------------------------------------------------------------------------
+# 3. canonicalization: equivalent values -> same digest
+# ---------------------------------------------------------------------------
+
+def test_canonicalization_equivalent_values_same_digest():
+    # (a) JCS: object key order + insignificant whitespace are irrelevant.
+    a = {"b": 1, "a": {"y": 2, "x": 3}}
+    b = {"a": {"x": 3, "y": 2}, "b": 1}
+    assert identity.canonicalize(a) == identity.canonicalize(b)
+    assert identity.canonical_digest("t", a) == identity.canonical_digest("t", b)
+
+    # (b) numbers normalize via Decimal, no float round-trip.
+    assert identity.canonicalize(1e3) == identity.canonicalize(1000)
+    assert identity.canonicalize(1000) == identity.canonicalize(Decimal("1E3"))
+    assert identity.canonicalize(5.0) == identity.canonicalize(5)
+    assert identity.canonicalize(5.00) == identity.canonicalize(Decimal("5.00"))
+    assert identity.canonicalize(5) == identity.canonicalize(Decimal("5.00"))
+
+    # (c) Unicode NFC vs NFD forms collapse before hashing.
+    nfc = "é"          # é  (composed)
+    nfd = "é"         # e + combining acute (decomposed)
+    assert nfc != nfd
+    assert identity.canonicalize(nfc) == identity.canonicalize(nfd)
+
+    # (d) a physical quantity MUST be an explicit {value, unit} pair; a bare
+    # units-bearing numeric string is rejected.
+    with pytest.raises(identity.IdentityError):
+        identity.canonicalize("5 kg")
+    with pytest.raises(identity.IdentityError):
+        identity.canonicalize({"mass": "5.0m"})
+    # the explicit pair is accepted
+    identity.canonicalize({"mass": {"value": 5.0, "unit": "kg"}})
+
+
+# ---------------------------------------------------------------------------
+# 4. different inputs never collide (incl. near-collision)
+# ---------------------------------------------------------------------------
+
+def test_different_inputs_never_collide():
+    assert identity.canonical_digest("t", {"v": 1.0}) != identity.canonical_digest(
+        "t", {"v": 1.0000000001})
+    assert identity.canonical_digest("t", [1, 2]) != identity.canonical_digest(
+        "t", [2, 1])  # arrays are ordered
+    assert identity.canonical_digest("t", {"a": 1}) != identity.canonical_digest(
+        "t", {"a": 1, "b": None})  # explicit null is a real difference, not omitted
+
+
+# ---------------------------------------------------------------------------
+# 5. domain separation prevents cross-type collision
+# ---------------------------------------------------------------------------
+
+def test_domain_separation_prevents_cross_type_collision():
+    components = {"role": "primary", "x": 1}
+    a = identity.canonical_digest("algorithm_version_id", components)
+    b = identity.canonical_digest("input_record_id", components)
+    c = identity.canonical_digest("run_id", components)
+    assert len({a, b, c}) == 3, "same bytes under different id types must not collide"
+    # and equal type + equal bytes DO agree (determinism)
+    assert a == identity.canonical_digest("algorithm_version_id", dict(components))
+
+
+# ---------------------------------------------------------------------------
+# 6. canonicalization_version is in every digest and pins the scheme
+# ---------------------------------------------------------------------------
+
+def test_canonicalization_version_in_digests_and_pins_scheme(monkeypatch):
+    before = identity.canonical_digest("t", {"a": 1})
+    assert isinstance(identity.CANONICALIZATION_VERSION, str)
+    monkeypatch.setattr(identity, "CANONICALIZATION_VERSION", "identity-jcs-999")
+    after = identity.canonical_digest("t", {"a": 1})
+    assert before != after, "bumping the scheme version must mint new ids deterministically"
+
+
+# ---------------------------------------------------------------------------
+# 7. fail-closed eligibility
+# ---------------------------------------------------------------------------
+
+def _eligible(**overrides):
+    kwargs = dict(
+        clean_tree=True,
+        commit="a" * 40,
+        commit_known=True,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-1",
+        seed=0,
+        execution_parameters={},
+    )
+    kwargs.update(overrides)
+    return identity.check_eligibility(**kwargs)
+
+
+def test_dirty_or_unpinned_or_implicit_seed_fails_closed():
+    # baseline is eligible
+    assert _eligible() is True
+
+    reject_cases = [
+        dict(clean_tree=False),                       # dirty_source
+        dict(commit_known=False),                     # unknown_revision (shallow/unknown)
+        dict(commit=None),                            # unknown_revision (no commit)
+        dict(input_schema_version=None),              # unpinned_schema
+        dict(output_schema_version=None),             # unpinned_schema
+        dict(environment_digest=None),                # missing_environment_digest
+        dict(seed=None),                              # implicit_seed
+        dict(execution_parameters=None),              # implicit_execution_default
+    ]
+    for case in reject_cases:
+        with pytest.raises(identity.EligibilityError):
+            _eligible(**case)
+
+    # seed == 0 is EXPLICIT (must not be treated as implicit)
+    assert _eligible(seed=0) is True
+
+
+# ---------------------------------------------------------------------------
+# 8. same canonical inputs -> same run_id across machines
+# ---------------------------------------------------------------------------
+
+def test_same_canonical_inputs_same_run_id_cross_machine(monkeypatch, tmp_path):
+    a = _derive()
+    # simulate a different machine: different cwd + different environment
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOSTNAME", "machine-b")
+    monkeypatch.setenv("PWD", str(tmp_path))
+    monkeypatch.setenv("USER", "someone-else")
+    b = _derive()
+    assert a["run_id"] == b["run_id"]
+    assert a["algorithm_version_id"] == b["algorithm_version_id"]
+    assert a["input_set_id"] == b["input_set_id"]
+
+
+# ---------------------------------------------------------------------------
+# 9. any component change changes identity
+# ---------------------------------------------------------------------------
+
+def test_any_component_change_changes_identity():
+    base = _derive()["run_id"]
+    assert _derive(semantic_version="9.9.9")["run_id"] != base
+    assert _derive(clean_git_commit="f" * 40)["run_id"] != base
+    assert _derive(environment_digest="env-other")["run_id"] != base
+    assert _derive(inputs=[("primary", "irid-1"), ("aux", "irid-CHANGED")])["run_id"] != base
+    assert _derive(execution_parameters={"tolerance": "1e-6", "mode": "slow"})["run_id"] != base
+    assert _derive(seed=4321)["run_id"] != base
+
+
+# ---------------------------------------------------------------------------
+# 10. execution_parameters vs parameter_set are not double-counted
+# ---------------------------------------------------------------------------
+
+def test_execution_parameter_and_parameter_set_not_double_counted():
+    # input_set_id depends ONLY on the input records, never on execution_parameters.
+    isid_a = identity.input_set_id([("primary", "irid-1")])
+    isid_b = identity.input_set_id([("primary", "irid-1")])
+    assert isid_a == isid_b
+
+    # A knob living on the execution side moves run_id but NOT input_set_id.
+    r1 = _derive(execution_parameters={"knob": "A"})
+    r2 = _derive(execution_parameters={"knob": "B"})
+    assert r1["input_set_id"] == r2["input_set_id"]   # not leaking into the input side
+    assert r1["run_id"] != r2["run_id"]
+
+    # The same logical value expressed on the INPUT side (a different input record)
+    # moves input_set_id (and run_id) but leaves execution_parameters untouched --
+    # i.e. it is counted on exactly one side, never both.
+    r3 = _derive(inputs=[("primary", "irid-knobA")], execution_parameters={})
+    r4 = _derive(inputs=[("primary", "irid-knobB")], execution_parameters={})
+    assert r3["input_set_id"] != r4["input_set_id"]
+    assert r3["run_id"] != r4["run_id"]
+
+
+# ---------------------------------------------------------------------------
+# 11. run_id uses an opaque injected input_set_id (no #3430 dependency)
+# ---------------------------------------------------------------------------
+
+def test_run_id_uses_opaque_injected_input_set_digest():
+    avid = _avid()
+    opaque = "0" * 64  # a stand-in input_set_id we did not compute here
+    rid = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=opaque,
+        execution_parameters={"mode": "fast"},
+        seed=1,
+    )
+    assert isinstance(rid, str) and len(rid) == 64
+    # a different opaque digest yields a different run_id, with no knowledge of
+    # how the input_set_id was constructed (that is #3430's concern).
+    rid2 = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id="1" * 64,
+        execution_parameters={"mode": "fast"},
+        seed=1,
+    )
+    assert rid != rid2
+
+
+# ---------------------------------------------------------------------------
+# 12. exact-rerun output mismatch fails closed without mutation
+# ---------------------------------------------------------------------------
+
+def test_exact_rerun_output_mismatch_fails_closed_no_mutation():
+    assert identity.OUTPUT_EQUALITY_DEFAULT == "raw_bytes_sha256"
+    prior = {"run_id": "r1", "output_equality_digest": "aa" * 32, "published": True}
+
+    # equal digests -> accepted (no exception)
+    identity.assert_output_equality(prior["output_equality_digest"], "aa" * 32)
+
+    # mismatch -> reject WITHOUT mutating the prior record
+    snapshot = dict(prior)
+    with pytest.raises(identity.OutputMismatchError):
+        identity.assert_output_equality(
+            prior["output_equality_digest"], "bb" * 32, prior_record=prior)
+    assert prior == snapshot, "reject_without_mutation: prior state must be untouched"
+
+
+# ---------------------------------------------------------------------------
+# 13. terminal statuses carry run_id; indeterminate mints none
+# ---------------------------------------------------------------------------
+
+def test_terminal_statuses_have_no_attempt_identity():
+    rid = _derive()["run_id"]
+    assert identity.mints_identity("succeeded") is True
+    assert identity.mints_identity("reproducible_failure") is True
+    assert identity.mints_identity("indeterminate_failure") is False
+
+    assert identity.run_identity_for_status("succeeded", rid) == rid
+    assert identity.run_identity_for_status("reproducible_failure", rid) == rid
+    # non-terminal, non-identity-bearing -> mints NO identity (attempts/retries never do)
+    assert identity.run_identity_for_status("indeterminate_failure", rid) is None
+
+
+# ---------------------------------------------------------------------------
+# 14. input_record_id forbids run-scoped and PII components
+# ---------------------------------------------------------------------------
+
+def test_input_record_id_forbids_run_scoped_and_pii_components():
+    good = identity.input_record_id(_input_record())
+    assert isinstance(good, str) and len(good) == 64
+
+    forbidden_examples = [
+        "run_id", "algorithm_version_id", "output_set_id", "attempt_id",
+        "retry_count", "publication_state", "tenant_id", "customer_id",
+        "request_id", "session_id", "user_id",
+    ]
+    for bad_key in forbidden_examples:
+        rec = _input_record(**{bad_key: "leak"})
+        with pytest.raises(identity.IdentityError):
+            identity.input_record_id(rec)
+
+    # a missing required component is likewise rejected (fail-closed)
+    incomplete = _input_record()
+    del incomplete["artifact_sha256"]
+    with pytest.raises(identity.IdentityError):
+        identity.input_record_id(incomplete)
+
+
+# ---------------------------------------------------------------------------
+# 15. envelope hashes are evidence, never identity inputs
+# ---------------------------------------------------------------------------
+
+def test_envelope_hashes_are_evidence_not_identity():
+    # The identity-derivation entrypoint deliberately consumes NEITHER the
+    # envelope input_hash NOR the best-effort code_version git_sha.
+    params = set(inspect.signature(identity.derive_run_identity).parameters)
+    assert "input_hash" not in params
+    assert "git_sha" not in params
+    for p in params:
+        assert "input_hash" not in p and "git_sha" not in p and "envelope" not in p
+
+    # Concretely: two runs whose ONLY difference is fabricated envelope evidence
+    # (a different volatile input_hash / best-effort git_sha) share one run_id,
+    # because that evidence is never passed into identity.
+    a = _derive()
+    _evidence_a = {"input_hash": "deadbeef", "git_sha": "1111111"}  # noqa: F841 -- not consumed
+    b = _derive()
+    _evidence_b = {"input_hash": "cafef00d", "git_sha": "2222222"}  # noqa: F841 -- not consumed
+    assert a["run_id"] == b["run_id"]
+    # identity is bound to the VERIFIED clean commit, not the best-effort sha
+    assert a["algorithm_version_id"] == b["algorithm_version_id"]

--- a/tests/workflow_api/test_output_contract.py
+++ b/tests/workflow_api/test_output_contract.py
@@ -1,0 +1,439 @@
+# ABOUTME: TDD tests for the curated-output + rolling-report contract
+# ABOUTME: (workspace-hub#3431): curated taxonomy, digest_contribution, output_equality_digest,
+# ABOUTME: failure disjointness/signature stability, surface eligibility, and the rolling report.
+"""Curated output + rolling algorithm report contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``records.output`` +
+``identity.output_equality`` + ``failure_policy`` blocks:
+
+- An Output record carries role, native_schema {id, version}, media_type,
+  shape/row_count, per-field units, coordinate/sign convention (when applicable),
+  validation_state, review_state, artifact_refs (referencing Artifacts by
+  content_digest via :mod:`artifact`) and ``digest_contribution``.
+- Curated-vs-excluded is a declared allowlist (primary_result / validation_evidence
+  / selected_report / decision_support). Anything unlabeled defaults to EXCLUDED
+  (fail-closed) -- never recorded / digested.
+- ``digest_contribution`` DEFAULTS to ``included``; ``excluded`` is permitted ONLY
+  via an explicitly declared + justified rule (fail-closed).
+- ``output_equality_digest`` (default ``raw_bytes_sha256``) is a
+  digest-of-sorted-digests, NOT raw byte concatenation. A semantic canonicalizer is
+  allowed ONLY when the 5 fields are declared; undeclared normalization is
+  presentation_only. Exact-rerun mismatch rejects without mutation (identity policy).
+- Success vs failure requirement sets are provably disjoint: ``failure_signature``
+  is the XOR discriminator. The signature strips volatile paths/timestamps/pids/hosts
+  and normalizes stack frames by module qualname so the same fault hashes identically
+  cross-machine. Failed runs are eligible only for run_health / diagnostics.
+- The rolling report renders mandatory Inputs + Outputs, separates failed runs, pins
+  every displayed run to an EXACT HF revision (a moving ref fails), draws eligibility
+  from a SOURCE-REPO ledger (not HF visibility), and is HTML-safe.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from assetutilities.workflow_api import identity, output_contract, report
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _digest(tag: str) -> str:
+    return hashlib.sha256(tag.encode()).hexdigest()
+
+
+def _schema(**over) -> dict:
+    base = {
+        "id": "well-log-v",
+        "version": "2.1.0",
+        "fields": {"depth_m": "number", "name": "string"},
+        "required": ["depth_m"],
+    }
+    base.update(over)
+    return base
+
+
+def _ref(tag: str) -> dict:
+    return {"content_digest": _digest(tag)}
+
+
+def _curated_output(*, label="primary_result", refs=("a",), digest_contribution=None,
+                    exclusion_rule=None, **over) -> dict:
+    kwargs = dict(
+        role="result_table",
+        native_schema=_schema(),
+        media_type="application/json",
+        curated_label=label,
+        artifact_refs=[_ref(t) for t in refs],
+        row_count=3,
+        units={"depth_m": "m"},
+    )
+    if digest_contribution is not None:
+        kwargs["digest_contribution"] = digest_contribution
+    if exclusion_rule is not None:
+        kwargs["exclusion_rule"] = exclusion_rule
+    kwargs.update(over)
+    return output_contract.make_output_record(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. output record fields + native schema preserved
+# ---------------------------------------------------------------------------
+
+def test_output_record_fields_and_native_schema_preserved():
+    rec = output_contract.make_output_record(
+        role="result_table",
+        native_schema=_schema(),
+        media_type="application/json",
+        curated_label="primary_result",
+        artifact_refs=[_ref("a")],
+        shape=[3, 2],
+        row_count=3,
+        units={"depth_m": "m"},
+        convention={"axis": "z-down", "sign": "compression-positive"},
+        validation_state="validated",
+        review_state="reviewed",
+    )
+    for field in ("role", "native_schema", "media_type", "shape", "row_count",
+                  "units", "convention", "validation_state", "review_state",
+                  "artifact_refs", "digest_contribution", "curated_label"):
+        assert field in rec
+    # native_schema preserved verbatim (id + version at minimum)
+    assert rec["native_schema"]["id"] == "well-log-v"
+    assert rec["native_schema"]["version"] == "2.1.0"
+    # artifact_refs reference artifacts by content_digest (do NOT redefine artifacts)
+    assert rec["artifact_refs"][0]["content_digest"] == _digest("a")
+    # residency + dataset_table match the on-main contract
+    assert output_contract.DATASET_TABLE == "outputs"
+    assert output_contract.RESIDENCY == "hf_object_and_normalized_record"
+
+
+# ---------------------------------------------------------------------------
+# 2. curated taxonomy allowlist; unlabeled defaults EXCLUDED (fail-closed)
+# ---------------------------------------------------------------------------
+
+def test_curated_taxonomy_allowlist_unlabeled_defaults_excluded():
+    assert output_contract.CURATED_LABELS == frozenset(
+        {"primary_result", "validation_evidence", "selected_report", "decision_support"}
+    )
+    for good in output_contract.CURATED_LABELS:
+        assert output_contract.is_curated_label(good) is True
+    # unlabeled / unknown -> excluded (never recorded)
+    assert output_contract.is_curated_label(None) is False
+    assert output_contract.is_curated_label("scratch_dump") is False
+
+    # an unlabeled output cannot be recorded at all (fail-closed)
+    with pytest.raises(output_contract.OutputContractError):
+        _curated_output(label=None)
+    with pytest.raises(output_contract.OutputContractError):
+        _curated_output(label="scratch_dump")
+
+
+# ---------------------------------------------------------------------------
+# 3. digest_contribution defaults included; exclusion must be declared+justified
+# ---------------------------------------------------------------------------
+
+def test_digest_contribution_defaults_included_and_exclusion_must_be_declared():
+    rec = _curated_output()
+    assert rec["digest_contribution"] == "included"
+
+    # silent / undeclared exclusion fails closed
+    with pytest.raises(output_contract.OutputContractError):
+        _curated_output(digest_contribution="excluded")
+    with pytest.raises(output_contract.OutputContractError):
+        _curated_output(digest_contribution="excluded", exclusion_rule={"rule_id": "r1"})
+
+    # a declared + justified exclusion rule is permitted
+    ex = _curated_output(
+        digest_contribution="excluded",
+        exclusion_rule={"rule_id": "constant-header",
+                        "justification": "byte-identical constant banner, reproduced exactly"},
+    )
+    assert ex["digest_contribution"] == "excluded"
+    assert ex["exclusion_rule"]["rule_id"] == "constant-header"
+
+
+# ---------------------------------------------------------------------------
+# 4. output_equality_digest = digest-of-sorted-digests (NOT concatenation)
+# ---------------------------------------------------------------------------
+
+def test_output_equality_digest_is_digest_of_sorted_artifact_digests():
+    o1 = _curated_output(refs=("x", "y"))
+    o2 = _curated_output(label="validation_evidence", refs=("z",))
+
+    res = output_contract.output_equality_digest([o1, o2])
+    assert res["algorithm"] == "raw_bytes_sha256"
+
+    all_digs = sorted([_digest("x"), _digest("y"), _digest("z")])
+    expected = hashlib.sha256(identity.canonicalize(all_digs).encode()).hexdigest()
+    assert res["digest"] == expected
+
+    # NOT raw byte concatenation (boundary-ambiguous)
+    concat = hashlib.sha256("".join(all_digs).encode()).hexdigest()
+    assert res["digest"] != concat
+
+    # order independence (sorted): reversed input -> same digest
+    res_rev = output_contract.output_equality_digest([o2, o1])
+    assert res_rev["digest"] == res["digest"]
+
+    # a declared-excluded output does NOT contribute to the digest
+    o_excl = _curated_output(
+        refs=("w",),
+        digest_contribution="excluded",
+        exclusion_rule={"rule_id": "r", "justification": "nondeterministic-but-approved presentation only"},
+    )
+    res_with_excl = output_contract.output_equality_digest([o1, o2, o_excl])
+    assert res_with_excl["digest"] == res["digest"]
+
+
+# ---------------------------------------------------------------------------
+# 5. undeclared semantic canonicalizer fails closed (declared needs 5 fields)
+# ---------------------------------------------------------------------------
+
+def test_undeclared_semantic_canonicalizer_fails_closed():
+    o1 = _curated_output(refs=("x",))
+    assert output_contract.SEMANTIC_EXCEPTION_REQUIRED == (
+        "canonicalizer_id", "canonicalizer_version", "raw_hash", "semantic_hash", "explicit_approval",
+    )
+
+    # partial declaration -> fail closed
+    with pytest.raises(output_contract.OutputContractError):
+        output_contract.output_equality_digest(
+            [o1], semantic_canonicalizer={"canonicalizer_id": "sortcols", "canonicalizer_version": "1"},
+        )
+
+    # full declaration -> semantic algorithm, digest is the declared semantic_hash
+    decl = {
+        "canonicalizer_id": "sortcols",
+        "canonicalizer_version": "1.0.0",
+        "raw_hash": _digest("raw"),
+        "semantic_hash": _digest("sem"),
+        "explicit_approval": "owner@ok",
+    }
+    res = output_contract.output_equality_digest([o1], semantic_canonicalizer=decl)
+    assert res["digest"] == _digest("sem")
+    assert res["algorithm"].startswith("semantic:")
+
+
+# ---------------------------------------------------------------------------
+# 6. exact-rerun output mismatch rejects without mutation
+# ---------------------------------------------------------------------------
+
+def test_exact_rerun_output_mismatch_rejects_without_mutation():
+    run1 = output_contract.output_equality_digest([_curated_output(refs=("x",))])
+    run2 = output_contract.output_equality_digest([_curated_output(refs=("DIFFERENT",))])
+    assert run1["digest"] != run2["digest"]
+
+    prior = {"run_id": "r-1", "output_equality_digest": run1["digest"]}
+    snapshot = dict(prior)
+    with pytest.raises(identity.OutputMismatchError):
+        output_contract.assert_output_equality(run1["digest"], run2["digest"], prior_record=prior)
+    # reject_without_mutation: prior record untouched
+    assert prior == snapshot
+
+    # equal digests accepted
+    assert output_contract.assert_output_equality(run1["digest"], run1["digest"]) is True
+
+
+# ---------------------------------------------------------------------------
+# 7. success vs failure requirement sets are disjoint (failure_signature XOR)
+# ---------------------------------------------------------------------------
+
+def test_success_and_failure_requirements_disjoint():
+    norm = output_contract.make_failure_normalization(
+        failure_phase="solve",
+        failure_code="singular_matrix",
+        failure_signature="fsig-1:abc",
+        curated_diagnostic_digests=[_digest("diag")],
+        replay_evidence={"seed": 7, "inputs": "input_set_id:1"},
+    )
+    # reproducible_failure MUST carry a failure_signature
+    output_contract.assert_status_requirements("reproducible_failure", norm)
+    with pytest.raises(output_contract.OutputContractError):
+        output_contract.assert_status_requirements(
+            "reproducible_failure", {k: v for k, v in norm.items() if k != "failure_signature"}
+        )
+
+    # succeeded MUST NOT carry a failure_signature (XOR discriminator)
+    output_contract.assert_status_requirements("succeeded", {"outputs": ["o1"]})
+    with pytest.raises(output_contract.OutputContractError):
+        output_contract.assert_status_requirements("succeeded", {"failure_signature": "fsig-1:abc"})
+
+
+# ---------------------------------------------------------------------------
+# 8. failure_signature stable cross-machine
+# ---------------------------------------------------------------------------
+
+def test_failure_signature_stable_cross_machine():
+    machine_a = dict(
+        phase="solve",
+        code="ZeroDivisionError",
+        frames=[
+            {"file": "/home/alice/proj/.venv/lib/python3.11/site-packages/numpy/core/_methods.py",
+             "func": "_mean", "lineno": 42},
+            {"file": "/home/alice/proj/src/algo/run.py", "module": "algo.run", "func": "solve", "lineno": 88},
+        ],
+        detail="failed at 2026-07-11T14:58:01Z pid=12345 host=ace-linux-1 in /home/alice/proj/tmp/x",
+    )
+    machine_b = dict(
+        phase="solve",
+        code="ZeroDivisionError",
+        frames=[
+            {"file": "/opt/ci/build/.venv/lib/python3.11/site-packages/numpy/core/_methods.py",
+             "func": "_mean", "lineno": 47},
+            {"file": "/opt/ci/build/src/algo/run.py", "module": "algo.run", "func": "solve", "lineno": 91},
+        ],
+        detail="failed at 2026-07-12T09:03:55Z pid=999 host=ci-runner-7 in /opt/ci/build/tmp/y",
+    )
+    sig_a = output_contract.failure_signature(**machine_a)
+    sig_b = output_contract.failure_signature(**machine_b)
+    assert sig_a == sig_b  # same fault -> identical signature cross-machine
+
+    # a genuinely different fault (different code) -> different signature
+    other = dict(machine_a)
+    other["code"] = "ValueError"
+    assert output_contract.failure_signature(**other) != sig_a
+
+
+# ---------------------------------------------------------------------------
+# 9. failed run forbidden from metric/insight/decision surfaces
+# ---------------------------------------------------------------------------
+
+def test_failed_run_forbidden_from_metric_insight_decision_surfaces():
+    assert output_contract.FAILURE_ELIGIBLE_SURFACES == frozenset({"run_health", "diagnostics"})
+    assert output_contract.FAILURE_FORBIDDEN_SURFACES == frozenset(
+        {"metric_observations", "insights", "decision_briefs"}
+    )
+    for surface in output_contract.FAILURE_ELIGIBLE_SURFACES:
+        assert output_contract.assert_surface_allowed("reproducible_failure", surface) is True
+    for surface in output_contract.FAILURE_FORBIDDEN_SURFACES:
+        with pytest.raises(output_contract.OutputContractError):
+            output_contract.assert_surface_allowed("reproducible_failure", surface)
+    # a succeeded run may publish to any of those surfaces
+    assert output_contract.assert_surface_allowed("succeeded", "decision_briefs") is True
+
+
+# ---------------------------------------------------------------------------
+# 10. report pins an EXACT HF revision (moving ref fails)
+# ---------------------------------------------------------------------------
+
+_EXACT_REV = "a" * 40
+
+
+def _run(run_id="r-1", status="succeeded", rev=_EXACT_REV, **over):
+    base = dict(
+        run_id=run_id,
+        status=status,
+        hf_revision=rev,
+        inputs=[{"name": "grid", "value": "512x512"}],
+        outputs=[{"role": "result_table", "value": "ok"}],
+    )
+    base.update(over)
+    return base
+
+
+def _ledger(*run_ids):
+    return [{"run_id": rid, "published": True} for rid in run_ids]
+
+
+def test_report_pins_exact_revision_moving_ref_fails():
+    assert report.is_exact_revision(_EXACT_REV) is True
+    for moving in ("main", "HEAD", "refs/heads/main", "v1.0.0", "a" * 39):
+        assert report.is_exact_revision(moving) is False
+
+    runs = [_run(rev=_EXACT_REV)]
+    ledger = _ledger("r-1")
+    # finalized (pinned) with an exact revision succeeds and shows the revision
+    html = report.render_report(algorithm="deep-solver", runs=runs, ledger=ledger, pinned=True)
+    assert _EXACT_REV in html
+
+    # a pinned report over a moving ref fails
+    with pytest.raises(output_contract.OutputContractError):
+        report.render_report(
+            algorithm="deep-solver", runs=[_run(rev="main")], ledger=ledger, pinned=True
+        )
+    # a DRAFT (unpinned) report tolerates a not-yet-pinned revision
+    draft = report.render_report(
+        algorithm="deep-solver", runs=[_run(rev="main")], ledger=ledger, pinned=False
+    )
+    assert "DRAFT" in draft.upper()
+
+
+# ---------------------------------------------------------------------------
+# 11. report renders mandatory Inputs + Outputs and separates failed runs
+# ---------------------------------------------------------------------------
+
+def test_report_renders_mandatory_inputs_outputs_and_separates_failures():
+    runs = [
+        _run(run_id="r-ok", status="succeeded",
+             optional={"convergence": "residual 1e-9 in 12 iters"}),
+        _run(run_id="r-bad", status="reproducible_failure",
+             outputs=[], inputs=[{"name": "grid", "value": "1024"}]),
+    ]
+    ledger = _ledger("r-ok", "r-bad")
+    html = report.render_report(algorithm="deep-solver", runs=runs, ledger=ledger, pinned=True)
+
+    # mandatory sections always present
+    assert "Inputs" in html
+    assert "Outputs" in html
+    # only-applicable optional section rendered when provided...
+    assert "convergence" in html
+    # ...and absent when not provided (no empty optional scaffolding)
+    assert "sensitivity" not in html
+    # failed run is clearly separated + labelled
+    assert "failed-run" in html
+    assert "r-bad" in html and "r-ok" in html
+    # the failed run id appears after the failed-runs boundary
+    assert html.index("failed-run") < html.index("r-bad")
+
+
+# ---------------------------------------------------------------------------
+# 12. report eligibility from the SOURCE-REPO ledger, not HF visibility
+# ---------------------------------------------------------------------------
+
+def test_report_eligibility_from_source_repo_ledger_not_hf_visibility():
+    runs = [
+        _run(run_id="r-published", hf_visible=False),   # in ledger, HF says hidden
+        _run(run_id="r-unpublished", hf_visible=True),  # NOT in ledger, HF says visible
+    ]
+    ledger = _ledger("r-published")  # source-repo publications.jsonl is the source of truth
+    html = report.render_report(algorithm="deep-solver", runs=runs, ledger=ledger, pinned=True)
+    assert "r-published" in html      # ledger wins over HF invisibility
+    assert "r-unpublished" not in html  # HF visibility does NOT make it eligible
+
+
+# ---------------------------------------------------------------------------
+# 13. report rejects / escapes unsafe HTML
+# ---------------------------------------------------------------------------
+
+def test_report_rejects_unsafe_html():
+    payload = "<script>alert('x')</script>"
+    runs = [_run(run_id="r-xss", inputs=[{"name": "note", "value": payload}])]
+    ledger = _ledger("r-xss")
+    html = report.render_report(algorithm="deep-solver", runs=runs, ledger=ledger, pinned=True)
+    assert payload not in html          # raw script must never survive
+    assert "&lt;script&gt;" in html     # it is HTML-escaped instead
+
+
+# ---------------------------------------------------------------------------
+# 14. output violating its declared native schema is rejected
+# ---------------------------------------------------------------------------
+
+def test_output_violating_declared_native_schema_rejected():
+    schema = _schema()
+    # conforming payload passes
+    assert output_contract.assert_payload_conforms(schema, {"depth_m": 1500.0, "name": "A-1"}) is True
+
+    # missing required field
+    with pytest.raises(output_contract.OutputContractError):
+        output_contract.assert_payload_conforms(schema, {"name": "A-1"})
+    # wrong type
+    with pytest.raises(output_contract.OutputContractError):
+        output_contract.assert_payload_conforms(schema, {"depth_m": "deep", "name": "A-1"})
+    # undeclared extra field (fail-closed)
+    with pytest.raises(output_contract.OutputContractError):
+        output_contract.assert_payload_conforms(schema, {"depth_m": 1.0, "name": "A-1", "rogue": 9})


### PR DESCRIPTION
## workspace-hub #3431 — curated output + rolling algorithm report contract

Reference implementation + TDD proof. Stacked on #3428 identity (PR #111) + #3429 artifact (PR #112). Plan-approved (workspace-hub PR #3468).

**`workflow_api.output_contract` + `report`** (stdlib-only):
- **Output record**: role, native_schema, media_type, shape/units/convention, validation/review state, artifact_refs (by content_digest — never redefined). Curated allowlist (primary_result/validation_evidence/selected_report/decision_support); unlabeled ⇒ EXCLUDED (fail-closed).
- **`digest_contribution` defaults `included`**; `excluded` requires a declared+justified `exclusion_rule` (rule_id + justification) — closes the silent-exclusion / masked-reproducibility-defect hole.
- **`output_equality_digest`** = `sha256(identity.canonicalize(sorted per-artifact content_digests))` — digest-of-digests, boundary-safe (not concatenation); default `raw_bytes_sha256`; semantic canonicalizer only when explicitly declared (5 required fields); exact-rerun mismatch reuses identity's `reject_without_mutation` policy.
- **Success/failure disjoint** via `failure_signature` XOR; signature strips volatile paths/timestamps/pids/hosts and reduces stdlib/venv frames to `module.func` (cross-machine stable); failed runs eligible only for run_health/diagnostics, FORBIDDEN from metric/insight/decision surfaces.
- **Rolling report**: mandatory Inputs+Outputs, failed runs separated, every run pinned to an EXACT HF revision (moving/`main` ref fails), eligibility rendered from a SOURCE-REPO `publications.jsonl` ledger (not HF visibility), HTML-safe.

**Tests:** 14 first-fail TDD tests → green; full `tests/workflow_api/` suite **62 passed**.

Refs workspace-hub#3431 workspace-hub#3427 · consumes #3428/#3429 · consumed by #3433.