### PR TITLE
feat(workflow_api): replayable public input + snapshot contract (#3430)

### DIFF
--- a/src/assetutilities/workflow_api/artifact.py
+++ b/src/assetutilities/workflow_api/artifact.py
@@ -114,14 +114,29 @@ def physical_byte_digest(stored_bytes) -> str:
     return hashlib.sha256(bytes(stored_bytes)).hexdigest()
 
 
-def structured_object_digest(obj) -> str:
-    """Content_digest of a structured object via the JCS canonical form.
+def structured_stored_bytes(obj) -> bytes:
+    """The exact bytes a structured artifact resides as: its JCS canonical form.
 
-    Reuses :func:`identity.canonical_digest` (which hashes
-    ``identity.canonicalize(obj)`` with identity's domain-separation convention),
-    so two key-orderings of one object yield one digest.
+    These are the bytes the object store persists, so a plain re-hash of them
+    reproduces ``content_digest`` (see :func:`structured_object_digest`).
     """
-    return identity.canonical_digest(STRUCTURED_CONTENT_ID_TYPE, obj)
+    return identity.canonicalize(obj).encode("utf-8")
+
+
+def structured_object_digest(obj) -> str:
+    """Content_digest of a structured object = plain SHA-256 of its stored bytes.
+
+    A ``content_digest`` is a CONTENT ADDRESS, not an identity: it must equal a
+    plain ``sha256`` of the exact bytes that reside in the object store so any
+    third party (e.g. the publisher's object-store re-hash in workspace-hub#3433)
+    can revalidate integrity without knowing the artifact's type. The stored bytes
+    of a structured object are its JCS canonical form (:func:`structured_stored_bytes`),
+    so two key-orderings of one object still yield one digest. Domain separation is
+    an *identity* concern (distinguishing algorithm_version_id/run_id) and is
+    deliberately NOT applied here -- it would make the address disagree with a plain
+    byte re-hash.
+    """
+    return hashlib.sha256(structured_stored_bytes(obj)).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/src/assetutilities/workflow_api/artifact.py
+++ b/src/assetutilities/workflow_api/artifact.py
@@ -1,0 +1,381 @@
+# ABOUTME: Content-addressed artifact + HF-residency contract (workspace-hub#3429):
+# ABOUTME: byte-intrinsic SHA-256 identity, integrity-from-bytes, projection-time residency.
+"""Content-addressed artifacts and Hugging Face residency projection.
+
+This module implements the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``artifact`` record --
+``identity: content_digest``, ``residency:
+content_addressed_hf_object_or_explicit_exclusion``, ``dataset_table: artifacts``.
+It is stdlib-only (``hashlib``, ``json`` via :mod:`identity`) to keep the shared
+library dependency-free, matching :mod:`envelope` and :mod:`identity`.
+
+Design invariants (from the approved+remediated #3429 plan):
+
+- **Physical-byte artifact.** ``content_digest = sha256(exact immutable STORED
+  bytes)`` -- TRUE content addressing: this is exactly what a publisher re-hashes
+  from the object on disk. ``compression`` is PURELY DESCRIPTIVE metadata and
+  MUST NEVER trigger decode-before-hash (hashing "decoded" bytes is a rejected
+  design). ``size_bytes`` is the stored byte length.
+- **Structured-object artifact.** ``content_digest`` is derived through
+  :func:`identity.canonical_digest` over :func:`identity.canonicalize` (the single
+  JCS canonical-serialization owner), reusing identity's domain-separation
+  convention. Two key-orderings of one object -> one digest.
+- **Role-free identity.** The Artifact record carries ONLY byte-intrinsic fields
+  (``content_digest, size_bytes, media_type, native_format, compression,
+  schema_ref, storage_locator, license_evidence_ref``). Residency ``class``/role/
+  ``eligible`` live on the referencing Input/Output record, never here. Identical
+  bytes -> ONE artifact record regardless of how many runs/roles reference it.
+- **Integrity-from-bytes.** A reader re-hashes the object's actual bytes and
+  REJECTS any manifest-asserted digest that disagrees -- bytes win, the manifest
+  is untrusted (:func:`verify_integrity`).
+- **Storage-locator safety.** :func:`validate_storage_locator` rejects absolute
+  paths / ``~`` home / UNC (``\\``) / ``..`` traversal and enforces
+  ``storage_locator == "objects/" + content_digest[:2] + "/" + content_digest``.
+- **Residency / exclusion.** Eligibility is computed AT PROJECTION TIME as
+  (byte-intrinsic license evidence) x (per-reference role)
+  (:func:`project_reference_residency`), never stamped on the record. Excluded
+  roles (transient logs / caches / large regenerable dumps) get a VISIBLE
+  ``class: excluded`` marker, never silent omission. A dataset-level license can
+  NEVER grant rights absent from a specific artifact's ``license_evidence_ref``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from assetutilities.workflow_api import identity
+
+# The residency contract value from the on-main artifact record.
+RESIDENCY_CONTRACT = "content_addressed_hf_object_or_explicit_exclusion"
+DATASET_TABLE = "artifacts"
+
+# Projection outcome classes: an eligible reference lands as a content-addressed
+# HF object; anything else is an EXPLICIT exclusion (never silent omission).
+CLASS_HF_OBJECT = "content_addressed_hf_object"
+CLASS_EXCLUDED = "excluded"
+
+# Domain-separation type for a structured-object content_digest, so a structured
+# artifact never collides with a physical blob whose bytes equal the JCS form.
+STRUCTURED_CONTENT_ID_TYPE = "artifact_structured_content"
+
+# The exhaustive byte-intrinsic field set of an Artifact record. Any other field
+# (notably residency class/role/eligible) is forbidden on the record.
+ARTIFACT_FIELDS = (
+    "content_digest",
+    "size_bytes",
+    "media_type",
+    "native_format",
+    "compression",
+    "schema_ref",
+    "storage_locator",
+    "license_evidence_ref",
+)
+
+# Per-reference role policy. HF eligibility is only ever available to a
+# replay-critical public input or a curated native output; transient logs,
+# caches and large regenerable dumps are EXPLICITLY excluded by role. Any other
+# (unknown/ambiguous) role fails closed.
+ELIGIBLE_ROLE_KINDS = frozenset({"replay_critical_input", "curated_native_output"})
+EXCLUDED_ROLE_KINDS = frozenset({"transient_log", "cache", "large_regenerable_dump"})
+
+# License-evidence ``redistribution`` values that fail public projection.
+_NON_PUBLIC_REDISTRIBUTION = frozenset(
+    {"restricted", "client_specific", "non_redistributable", "forbidden"}
+)
+
+
+class ArtifactError(ValueError):
+    """Raised when an artifact record violates the byte-intrinsic contract."""
+
+
+class IntegrityError(ArtifactError):
+    """Raised when actual bytes disagree with a manifest-asserted content_digest."""
+
+
+class StorageLocatorError(ArtifactError):
+    """Raised for an unsafe or record-digest-mismatched storage locator."""
+
+
+# ---------------------------------------------------------------------------
+# content digests
+# ---------------------------------------------------------------------------
+
+def physical_byte_digest(stored_bytes) -> str:
+    """SHA-256 of the EXACT immutable stored bytes (true content addressing).
+
+    ``stored_bytes`` are the bytes as they physically reside in the object store.
+    Compression/encoding is never decoded first -- the digest is what a publisher
+    re-hashes from disk.
+    """
+    if not isinstance(stored_bytes, (bytes, bytearray, memoryview)):
+        raise ArtifactError(
+            f"physical artifact needs raw bytes, got {type(stored_bytes).__name__}"
+        )
+    return hashlib.sha256(bytes(stored_bytes)).hexdigest()
+
+
+def structured_object_digest(obj) -> str:
+    """Content_digest of a structured object via the JCS canonical form.
+
+    Reuses :func:`identity.canonical_digest` (which hashes
+    ``identity.canonicalize(obj)`` with identity's domain-separation convention),
+    so two key-orderings of one object yield one digest.
+    """
+    return identity.canonical_digest(STRUCTURED_CONTENT_ID_TYPE, obj)
+
+
+# ---------------------------------------------------------------------------
+# storage locator
+# ---------------------------------------------------------------------------
+
+def _digest_ok(content_digest) -> bool:
+    return (
+        isinstance(content_digest, str)
+        and len(content_digest) == 64
+        and all(c in "0123456789abcdef" for c in content_digest)
+    )
+
+
+def _validate_digest(content_digest) -> None:
+    if not _digest_ok(content_digest):
+        raise ArtifactError(
+            f"content_digest must be a 64-char lowercase hex SHA-256, got {content_digest!r}"
+        )
+
+
+def storage_locator_for(content_digest) -> str:
+    """Return the canonical sharded locator ``objects/<d[:2]>/<d>`` for a digest."""
+    _validate_digest(content_digest)
+    return "objects/" + content_digest[:2] + "/" + content_digest
+
+
+def _is_unsafe_locator(locator: str) -> bool:
+    if locator.startswith("/") or locator.startswith("~"):
+        return True  # absolute path or home reference
+    if "\\" in locator:
+        return True  # UNC (\\server\share) or a windows/backslash path
+    if ".." in locator.split("/"):
+        return True  # parent-directory traversal
+    return False
+
+
+def validate_storage_locator(locator, content_digest) -> bool:
+    """Validate a storage locator: reject unsafe paths and enforce digest binding.
+
+    Raises :class:`StorageLocatorError` for an absolute / ``~`` / UNC / ``..``
+    locator, or when ``locator != "objects/" + content_digest[:2] + "/" +
+    content_digest`` (shard prefix + full digest tied to the record's digest).
+    """
+    if not isinstance(locator, str) or not locator:
+        raise StorageLocatorError(f"storage_locator must be a non-empty string, got {locator!r}")
+    if _is_unsafe_locator(locator):
+        raise StorageLocatorError(
+            f"unsafe storage_locator {locator!r}: absolute/home/UNC/.. paths are forbidden"
+        )
+    _validate_digest(content_digest)
+    expected = "objects/" + content_digest[:2] + "/" + content_digest
+    if locator != expected:
+        raise StorageLocatorError(
+            f"storage_locator {locator!r} does not match this record's digest "
+            f"(expected {expected!r})"
+        )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# artifact record construction (role-free, byte-intrinsic only)
+# ---------------------------------------------------------------------------
+
+def make_artifact(
+    *,
+    content_digest,
+    size_bytes,
+    media_type,
+    native_format,
+    compression=None,
+    schema_ref=None,
+    storage_locator=None,
+    license_evidence_ref=None,
+    **forbidden,
+) -> dict:
+    """Build a byte-intrinsic Artifact record.
+
+    Rejects any residency ``class``/role/``eligible`` (or otherwise unexpected)
+    field via ``**forbidden`` -- those live on the referencing Input/Output
+    record, never on the artifact. When ``storage_locator`` is omitted it is
+    derived from the digest; when supplied it is validated against the digest.
+    """
+    if forbidden:
+        raise ArtifactError(
+            "artifact record is role-free / byte-intrinsic; forbidden fields: "
+            f"{sorted(forbidden)} (residency class/role/eligible live on the reference)"
+        )
+    _validate_digest(content_digest)
+    if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes < 0:
+        raise ArtifactError(f"size_bytes must be a non-negative int, got {size_bytes!r}")
+    if not media_type or not native_format:
+        raise ArtifactError("media_type and native_format are required byte-intrinsic fields")
+    if storage_locator is None:
+        storage_locator = storage_locator_for(content_digest)
+    else:
+        validate_storage_locator(storage_locator, content_digest)
+    return {
+        "content_digest": content_digest,
+        "size_bytes": size_bytes,
+        "media_type": media_type,
+        "native_format": native_format,
+        "compression": compression,
+        "schema_ref": schema_ref,
+        "storage_locator": storage_locator,
+        "license_evidence_ref": license_evidence_ref,
+    }
+
+
+def physical_artifact(
+    stored_bytes,
+    *,
+    media_type,
+    native_format,
+    compression=None,
+    schema_ref=None,
+    license_evidence_ref=None,
+) -> dict:
+    """Build an Artifact record from the exact stored bytes (content-addressed)."""
+    digest = physical_byte_digest(stored_bytes)
+    return make_artifact(
+        content_digest=digest,
+        size_bytes=len(bytes(stored_bytes)),
+        media_type=media_type,
+        native_format=native_format,
+        compression=compression,
+        schema_ref=schema_ref,
+        license_evidence_ref=license_evidence_ref,
+    )
+
+
+def structured_artifact(
+    obj,
+    *,
+    media_type="application/json",
+    native_format="jcs",
+    compression=None,
+    schema_ref=None,
+    license_evidence_ref=None,
+) -> dict:
+    """Build an Artifact record from a structured object via its JCS canonical form.
+
+    ``size_bytes`` is the byte length of the canonical serialization, so identical
+    objects (any key ordering) produce one identical record.
+    """
+    canon = identity.canonicalize(obj)
+    return make_artifact(
+        content_digest=structured_object_digest(obj),
+        size_bytes=len(canon.encode("utf-8")),
+        media_type=media_type,
+        native_format=native_format,
+        compression=compression,
+        schema_ref=schema_ref,
+        license_evidence_ref=license_evidence_ref,
+    )
+
+
+# ---------------------------------------------------------------------------
+# integrity: re-hash the actual bytes; the manifest is untrusted
+# ---------------------------------------------------------------------------
+
+def verify_integrity(record, *, stored_bytes=None, structured_object=None) -> bool:
+    """Re-hash the object's actual bytes and reject any disagreeing manifest.
+
+    Exactly one of ``stored_bytes`` / ``structured_object`` must be given. The
+    digest is recomputed from that actual object; if it disagrees with
+    ``record["content_digest"]`` we raise :class:`IntegrityError` (bytes win,
+    the manifest is never trusted). This covers both tampered bytes and a
+    hand-forged manifest digest. The storage locator is also re-checked against
+    the recomputed digest.
+    """
+    if (stored_bytes is None) == (structured_object is None):
+        raise ArtifactError("provide exactly one of stored_bytes / structured_object")
+    asserted = record.get("content_digest")
+    if stored_bytes is not None:
+        actual = physical_byte_digest(stored_bytes)
+    else:
+        actual = structured_object_digest(structured_object)
+    if actual != asserted:
+        raise IntegrityError(
+            f"content_digest mismatch: actual bytes hash to {actual} but the "
+            f"manifest asserts {asserted!r}; bytes win, manifest rejected"
+        )
+    locator = record.get("storage_locator")
+    if locator is not None:
+        validate_storage_locator(locator, actual)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# residency projection: eligibility = (byte-license) x (reference-role)
+# ---------------------------------------------------------------------------
+
+def _role_kind(role):
+    return role.get("kind") if isinstance(role, dict) else role
+
+
+def _license_permits_public(evidence):
+    """Return ``(permits, reason)`` for byte-intrinsic license evidence.
+
+    Only unambiguous, publicly-redistributable, non-path-leaking evidence
+    permits public projection. Missing evidence never permits it.
+    """
+    if evidence is None:
+        return False, "no_license_evidence"
+    if not isinstance(evidence, dict):
+        return False, "unstructured_license_evidence"
+    redistribution = evidence.get("redistribution")
+    if redistribution in _NON_PUBLIC_REDISTRIBUTION:
+        return False, f"redistribution_{redistribution}"
+    if redistribution != "public":
+        return False, "redistribution_not_public"
+    license_id = evidence.get("license")
+    if not license_id or license_id == "ambiguous":
+        return False, "ambiguous_license"
+    # a license reference that leaks a filesystem path is not publicly projectable.
+    for value in evidence.values():
+        if isinstance(value, str) and _is_unsafe_locator(value):
+            return False, "path_leak"
+    return True, "public_redistributable"
+
+
+def _excluded(record, reason) -> dict:
+    """A VISIBLE exclusion marker (never silent omission)."""
+    return {
+        "class": CLASS_EXCLUDED,
+        "reason": reason,
+        "content_digest": record.get("content_digest"),
+        "storage_locator": record.get("storage_locator"),
+    }
+
+
+def project_reference_residency(record, role, *, dataset_license=None) -> dict:
+    """Compute residency for one ``(artifact, referencing role)`` at projection time.
+
+    Returns a ``class: content_addressed_hf_object`` marker only when the role is
+    HF-eligible AND the artifact's OWN ``license_evidence_ref`` permits public
+    redistribution; otherwise a VISIBLE ``class: excluded`` marker with a reason.
+    ``dataset_license`` is accepted but can only ever RESTRICT -- it never grants
+    rights absent from the artifact's byte-intrinsic evidence.
+    """
+    kind = _role_kind(role)
+    if kind in EXCLUDED_ROLE_KINDS:
+        return _excluded(record, f"role_excluded:{kind}")
+    if kind not in ELIGIBLE_ROLE_KINDS:
+        return _excluded(record, f"ambiguous_role:{kind}")
+
+    permits, reason = _license_permits_public(record.get("license_evidence_ref"))
+    if not permits:
+        # a dataset-level license is deliberately NOT consulted to grant rights.
+        return _excluded(record, reason)
+    return {
+        "class": CLASS_HF_OBJECT,
+        "reason": f"eligible:{kind}:{reason}",
+        "content_digest": record.get("content_digest"),
+        "storage_locator": record.get("storage_locator"),
+    }

--- a/src/assetutilities/workflow_api/identity.py
+++ b/src/assetutilities/workflow_api/identity.py
@@ -1,0 +1,486 @@
+# ABOUTME: Deterministic run-identity contract (workspace-hub#3428): canonical
+# ABOUTME: serialization + domain-separated SHA-256 digests + fail-closed identity.
+"""Deterministic run identity.
+
+This module OWNS the canonical serialization for the deterministic-workflow epic
+(workspace-hub#3281) and mints the type-separated SHA-256 identities defined by
+the on-main ``docs/architecture/algorithm-run-dataset-contract.yaml`` ``identity``
+block. It is stdlib-only (``hashlib``, ``decimal``, ``unicodedata``, ``json``,
+``re``) to keep the shared library dependency-free, matching :mod:`envelope`.
+
+Design invariants:
+
+- **Canonical serialization owner = identity.** :func:`canonicalize` implements a
+  compact RFC 8785 (JCS) serializer: UTF-8, object keys sorted by UTF-16 code-unit
+  order, no insignificant whitespace, arrays in declared order. Strings are
+  Unicode-NFC-normalized before hashing; numbers normalize through
+  :class:`decimal.Decimal` with no float round-trip (``1e3 == 1000``,
+  ``5.0 == 5.00 == 5``); ``null``/NA is explicit and never omitted. A physical
+  quantity MUST be an explicit ``{"value": ..., "unit": ...}`` pair -- a bare
+  units-bearing numeric string (``"5 kg"``) is rejected.
+- **Domain separation.** Every digest is prefixed with its identity type AND the
+  :data:`CANONICALIZATION_VERSION`, so different id types never collide on equal
+  component bytes and a scheme change mints new ids deterministically.
+- **Identity is re-derived from a VERIFIED clean context** (a proven-clean commit
+  + declared env/schema pins + canonical inputs). The :class:`ResultEnvelope`
+  ``input_hash`` (volatile-key-pruned) and ``code_version.git_sha`` (best-effort,
+  no clean-tree proof) are EVIDENCE, never identity inputs;
+  :func:`derive_run_identity` deliberately consumes neither.
+- **Fail-closed.** :func:`check_eligibility` rejects dirty tree / unknown-or-shallow
+  revision / unpinned schema / missing environment digest / implicit seed /
+  implicit execution default before any id is minted.
+- ``run_id`` EXCLUDES outputs -- an exact rerun is the SAME ``run_id``. Output
+  equality is a separate ``output_equality_digest`` (owned by #3431) that this
+  module only references as an opaque injected value while owning the
+  mismatch -> reject-without-mutation POLICY (:func:`assert_output_equality`).
+  ``input_set_id`` per-input canonical field membership is #3430's concern; this
+  module consumes ``input_record_id`` values as given.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from decimal import Decimal
+
+# A change to this constant is a change to the serialization scheme; because it
+# participates in every digest, bumping it deterministically mints new ids.
+CANONICALIZATION_VERSION = "identity-jcs-1"
+
+# Default output-equality comparison (the digest itself is owned by #3431).
+OUTPUT_EQUALITY_DEFAULT = "raw_bytes_sha256"
+
+# ---- component contracts (verbatim from the on-main contract yaml) ----------
+ALGORITHM_VERSION_ID_REQUIRED = (
+    "algorithm_id",
+    "semantic_version",
+    "clean_git_commit",
+    "input_schema_version",
+    "output_schema_version",
+    "environment_digest",
+)
+INPUT_RECORD_ID_REQUIRED = (
+    "role",
+    "native_schema_version",
+    "source_snapshot",
+    "transformation_id",
+    "artifact_sha256",
+    "redistribution_rights",
+    "complete_replay_location",
+)
+INPUT_RECORD_ID_FORBIDDEN = (
+    "run_id",
+    "algorithm_version_id",
+    "output_set_id",
+    "attempt_id",
+    "retry_count",
+    "publication_state",
+    "tenant_id",
+    "customer_id",
+    "request_id",
+    "session_id",
+    "user_id",
+)
+RUN_ID_FORBIDDEN = (
+    "output_set_id",
+    "attempt_id",
+    "retry_count",
+    "publication_state",
+    "tenant_id",
+    "customer_id",
+    "request_id",
+    "api_request_id",
+    "session_id",
+    "user_id",
+)
+
+# Terminal, identity-bearing run statuses. ``indeterminate_failure`` is
+# non-terminal and mints NO identity (no attempt/retry identity ever exists:
+# a rerun of the same canonical inputs is the same run_id).
+IDENTITY_BEARING_STATUSES = frozenset({"succeeded", "reproducible_failure"})
+NON_TERMINAL_STATUSES = frozenset({"indeterminate_failure"})
+
+
+class IdentityError(ValueError):
+    """Raised when identity inputs violate the canonical-serialization contract."""
+
+
+class EligibilityError(IdentityError):
+    """Raised (fail-closed) when a run is not eligible to mint an identity."""
+
+
+class OutputMismatchError(IdentityError):
+    """Raised when an exact rerun's output digest differs from the recorded one."""
+
+
+# ---------------------------------------------------------------------------
+# canonical serialization (RFC 8785 / JCS, compact, stdlib-only)
+# ---------------------------------------------------------------------------
+
+# A bare "units-bearing numeric": a number immediately followed by a unit token
+# (letters / % / common symbols) with nothing else. Dates ("2026-07-11") and
+# plain identifiers do not match, so they are not falsely rejected.
+_UNITS_BEARING_RE = re.compile(
+    r"^\s*[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?\s*[A-Za-z%µμ°Ω/·]+\s*$"
+)
+
+
+def _reject_if_units_bearing(text: str) -> None:
+    if _UNITS_BEARING_RE.match(text):
+        raise IdentityError(
+            f"bare units-bearing numeric {text!r} rejected; represent a physical "
+            "quantity as an explicit {'value': ..., 'unit': ...} pair"
+        )
+
+
+def _number_canonical(value) -> str:
+    """Canonical decimal string for a number (no float round-trip, no exponent)."""
+    if isinstance(value, bool):  # defensive; bool handled before this is reached
+        raise IdentityError("bool is not a number")
+    if isinstance(value, float):
+        # str(float) yields the shortest round-trippable decimal, so we never
+        # bake in binary-float noise the way Decimal(float) would.
+        if value != value or value in (float("inf"), float("-inf")):
+            raise IdentityError(f"non-finite number not permitted: {value!r}")
+        dec = Decimal(str(value))
+    elif isinstance(value, int):
+        dec = Decimal(value)
+    elif isinstance(value, Decimal):
+        if not value.is_finite():
+            raise IdentityError(f"non-finite number not permitted: {value!r}")
+        dec = value
+    else:  # pragma: no cover - guarded by caller
+        raise IdentityError(f"unsupported numeric type: {type(value).__name__}")
+    if dec == 0:
+        return "0"
+    # normalize() collapses 5.00 -> 5 and 1000 -> 1E+3; format 'f' re-expands to
+    # plain decimal so 1e3, 1000 and Decimal('1E3') all render as "1000".
+    return format(dec.normalize(), "f")
+
+
+def _canon(value) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        _reject_if_units_bearing(value)
+        return json.dumps(unicodedata.normalize("NFC", value), ensure_ascii=False)
+    if isinstance(value, (int, float, Decimal)):
+        return _number_canonical(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canon(v) for v in value) + "]"
+    if isinstance(value, dict):
+        parts = []
+        # RFC 8785: sort object keys by UTF-16 code-unit order.
+        for key in sorted(value, key=lambda k: _utf16_sort_key(k)):
+            if not isinstance(key, str):
+                raise IdentityError(
+                    f"object keys must be strings, got {type(key).__name__}"
+                )
+            enc_key = json.dumps(unicodedata.normalize("NFC", key), ensure_ascii=False)
+            parts.append(enc_key + ":" + _canon(value[key]))
+        return "{" + ",".join(parts) + "}"
+    raise IdentityError(f"cannot canonicalize value of type {type(value).__name__}")
+
+
+def _utf16_sort_key(key) -> bytes:
+    if not isinstance(key, str):
+        raise IdentityError(f"object keys must be strings, got {type(key).__name__}")
+    return unicodedata.normalize("NFC", key).encode("utf-16-be")
+
+
+def canonicalize(value) -> str:
+    """Return the canonical (JCS) serialization of ``value`` as text.
+
+    This is the single canonical-serialization owner for the epic. It is
+    total for JSON-shaped values (``dict``/``list``/``str``/``int``/``float``/
+    ``Decimal``/``bool``/``None``) and raises :class:`IdentityError` for
+    non-serializable values or bare units-bearing numeric strings.
+    """
+    return _canon(value)
+
+
+def canonical_digest(identity_type: str, components) -> str:
+    """SHA-256 hex digest of ``components``, domain-separated by ``identity_type``.
+
+    The digest input is ``"{identity_type}\\n{CANONICALIZATION_VERSION}\\n{canon}"``
+    so (a) different id types never collide on equal component bytes and (b) a
+    serialization-scheme bump mints new ids for the same components.
+    """
+    if not isinstance(identity_type, str) or not identity_type:
+        raise IdentityError("identity_type must be a non-empty string")
+    canon = canonicalize(components)
+    payload = f"{identity_type}\n{CANONICALIZATION_VERSION}\n{canon}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# membership validation
+# ---------------------------------------------------------------------------
+
+def _validate_membership(id_type, components, *, required, forbidden=()):
+    if not isinstance(components, dict):
+        raise IdentityError(f"{id_type} components must be a dict")
+    present = set(components)
+    forb = present & set(forbidden)
+    if forb:
+        raise IdentityError(f"{id_type} forbids run-scoped/PII components: {sorted(forb)}")
+    missing = [k for k in required if k not in components or components[k] is None]
+    if missing:
+        raise IdentityError(f"{id_type} missing required components: {missing}")
+    extra = present - set(required)
+    if extra:
+        raise IdentityError(f"{id_type} has unexpected components: {sorted(extra)}")
+
+
+# ---------------------------------------------------------------------------
+# identity constructors
+# ---------------------------------------------------------------------------
+
+def algorithm_version_id(
+    *,
+    algorithm_id,
+    semantic_version,
+    clean_git_commit,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+) -> str:
+    """Mint an ``algorithm_version_id`` binding all six required components.
+
+    ``clean_git_commit`` MUST be a commit already VERIFIED clean/known upstream
+    (see :func:`check_eligibility`); this constructor only binds it.
+    """
+    components = {
+        "algorithm_id": algorithm_id,
+        "semantic_version": semantic_version,
+        "clean_git_commit": clean_git_commit,
+        "input_schema_version": input_schema_version,
+        "output_schema_version": output_schema_version,
+        "environment_digest": environment_digest,
+    }
+    _validate_membership(
+        "algorithm_version_id", components, required=ALGORITHM_VERSION_ID_REQUIRED
+    )
+    return canonical_digest("algorithm_version_id", components)
+
+
+def input_record_id(components: dict) -> str:
+    """Mint an ``input_record_id`` from its required components.
+
+    Rejects the forbidden run-scoped / PII components. The exact canonical field
+    membership beyond required/forbidden is #3430's concern; values are consumed
+    as given.
+    """
+    _validate_membership(
+        "input_record_id",
+        components,
+        required=INPUT_RECORD_ID_REQUIRED,
+        forbidden=INPUT_RECORD_ID_FORBIDDEN,
+    )
+    return canonical_digest("input_record_id", components)
+
+
+def input_set_id(inputs) -> str:
+    """Mint an ``input_set_id`` from ``(role, input_record_id)`` pairs.
+
+    ``inputs`` is an iterable of ``(role, input_record_id)`` tuples or
+    ``{"role": ..., "input_record_id": ...}`` mappings. Pairs are sorted so the
+    set identity is order-independent. ``input_record_id`` values are opaque
+    (they may be produced by #3430) -- this constructor does not re-derive them.
+    """
+    pairs = []
+    for item in inputs:
+        if isinstance(item, dict):
+            role = item["role"]
+            rec_id = item["input_record_id"]
+        else:
+            role, rec_id = item
+        if role is None or rec_id is None:
+            raise IdentityError("each input needs an explicit (role, input_record_id)")
+        pairs.append((role, rec_id))
+    pairs.sort(key=lambda p: (_utf16_sort_key(str(p[0])), _utf16_sort_key(str(p[1]))))
+    components = {
+        "inputs": [{"role": r, "input_record_id": rid} for r, rid in pairs]
+    }
+    return canonical_digest("input_set_id", components)
+
+
+def run_id(*, algorithm_version_id, input_set_id, execution_parameters, seed) -> str:
+    """Mint a ``run_id`` from ``algorithm_version_id`` + ``input_set_id`` +
+    ``execution_parameters`` + ``seed``.
+
+    EXCLUDES outputs (an exact rerun -> same ``run_id``). ``input_set_id`` is an
+    opaque injected digest. ``execution_parameters`` are run-control knobs only
+    (distinct from #3430 ``parameter_set`` inputs) and must not smuggle any
+    run-scoped/PII forbidden component. Seed and execution_parameters must be
+    explicit (fail-closed against implicit defaults).
+    """
+    if seed is None:
+        raise IdentityError("implicit_seed: an explicit seed is required")
+    if execution_parameters is None:
+        raise IdentityError(
+            "implicit_execution_default: explicit execution_parameters are required"
+        )
+    if not isinstance(execution_parameters, dict):
+        raise IdentityError("execution_parameters must be a dict")
+    forb = set(execution_parameters) & set(RUN_ID_FORBIDDEN)
+    if forb:
+        raise IdentityError(
+            f"run_id forbids run-scoped/PII components in execution_parameters: {sorted(forb)}"
+        )
+    if algorithm_version_id is None or input_set_id is None:
+        raise IdentityError("run_id requires algorithm_version_id and input_set_id")
+    components = {
+        "algorithm_version_id": algorithm_version_id,
+        "input_set_id": input_set_id,
+        "execution_parameters": execution_parameters,
+        "seed": seed,
+    }
+    return canonical_digest("run_id", components)
+
+
+# ---------------------------------------------------------------------------
+# fail-closed eligibility
+# ---------------------------------------------------------------------------
+
+def check_eligibility(
+    *,
+    clean_tree: bool,
+    commit,
+    commit_known: bool,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+    seed,
+    execution_parameters,
+) -> bool:
+    """Fail-closed gate: raise :class:`EligibilityError` unless a run may mint id.
+
+    Rejects (all -> reject): ``dirty_source``, ``unknown_revision`` (unknown or
+    shallow commit), ``unpinned_schema``, ``missing_environment_digest``,
+    ``implicit_seed``, ``implicit_execution_default``.
+    """
+    reasons = []
+    if not clean_tree:
+        reasons.append("dirty_source")
+    if not commit_known or not commit:
+        reasons.append("unknown_revision")
+    if not input_schema_version or not output_schema_version:
+        reasons.append("unpinned_schema")
+    if not environment_digest:
+        reasons.append("missing_environment_digest")
+    if seed is None:
+        reasons.append("implicit_seed")
+    if execution_parameters is None:
+        reasons.append("implicit_execution_default")
+    if reasons:
+        raise EligibilityError(f"run not eligible to mint identity: {reasons}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# high-level derivation from a VERIFIED clean context
+# ---------------------------------------------------------------------------
+
+def derive_run_identity(
+    *,
+    algorithm_id,
+    semantic_version,
+    clean_git_commit,
+    input_schema_version,
+    output_schema_version,
+    environment_digest,
+    inputs,
+    execution_parameters,
+    seed,
+    commit_known: bool = True,
+    clean_tree: bool = True,
+) -> dict:
+    """Re-derive ``{algorithm_version_id, input_set_id, run_id}`` from a VERIFIED
+    clean context.
+
+    Deliberately consumes NEITHER the envelope ``input_hash`` NOR the best-effort
+    ``code_version.git_sha`` -- those are evidence, not identity. Identity binds
+    the ``clean_git_commit`` proven clean here (fail-closed via
+    :func:`check_eligibility`) plus declared env/schema pins plus canonical inputs.
+    Reads nothing from the process environment or cwd, so the same canonical
+    inputs yield the same ``run_id`` on any machine.
+    """
+    check_eligibility(
+        clean_tree=clean_tree,
+        commit=clean_git_commit,
+        commit_known=commit_known,
+        input_schema_version=input_schema_version,
+        output_schema_version=output_schema_version,
+        environment_digest=environment_digest,
+        seed=seed,
+        execution_parameters=execution_parameters,
+    )
+    avid = algorithm_version_id(
+        algorithm_id=algorithm_id,
+        semantic_version=semantic_version,
+        clean_git_commit=clean_git_commit,
+        input_schema_version=input_schema_version,
+        output_schema_version=output_schema_version,
+        environment_digest=environment_digest,
+    )
+    isid = input_set_id(inputs)
+    rid = run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters=execution_parameters,
+        seed=seed,
+    )
+    return {"algorithm_version_id": avid, "input_set_id": isid, "run_id": rid}
+
+
+# ---------------------------------------------------------------------------
+# terminal-status identity semantics
+# ---------------------------------------------------------------------------
+
+def mints_identity(status: str) -> bool:
+    """True iff ``status`` is terminal + identity-bearing (succeeded /
+    reproducible_failure). ``indeterminate_failure`` is non-terminal -> False."""
+    return status in IDENTITY_BEARING_STATUSES
+
+
+def is_terminal_status(status: str) -> bool:
+    return status in IDENTITY_BEARING_STATUSES
+
+
+def run_identity_for_status(status: str, run_id_value: str):
+    """Return ``run_id_value`` for an identity-bearing terminal status, else
+    ``None`` for a non-terminal status (no attempt/retry identity is ever minted).
+    """
+    if status in IDENTITY_BEARING_STATUSES:
+        return run_id_value
+    if status in NON_TERMINAL_STATUSES:
+        return None
+    raise IdentityError(f"unknown run status: {status!r}")
+
+
+# ---------------------------------------------------------------------------
+# output-equality POLICY (digest owned by #3431; policy owned here)
+# ---------------------------------------------------------------------------
+
+def assert_output_equality(recorded_digest, observed_digest, *, prior_record=None) -> bool:
+    """Enforce the output-equality policy for an exact rerun.
+
+    The ``output_equality_digest`` itself is #3431's concern; here we only apply
+    the ``mismatch_action: reject_without_mutation`` POLICY. On mismatch we raise
+    :class:`OutputMismatchError` and mutate NOTHING (``prior_record`` is never
+    written to). Equal digests are accepted.
+    """
+    if recorded_digest != observed_digest:
+        raise OutputMismatchError(
+            "output_equality mismatch under "
+            f"{OUTPUT_EQUALITY_DEFAULT}: recorded={recorded_digest!r} "
+            f"observed={observed_digest!r}; reject_without_mutation"
+        )
+    return True

--- a/src/assetutilities/workflow_api/inputs.py
+++ b/src/assetutilities/workflow_api/inputs.py
@@ -1,0 +1,421 @@
+# ABOUTME: Replayable public input + source-snapshot contract (workspace-hub#3430):
+# ABOUTME: six closed input kinds, fail-closed admission, snapshot identity via #3428/#3429.
+"""Replayable inputs and the source-snapshot admission contract.
+
+This module implements the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``records.input`` record
+and ``public_input_policy`` block. It builds the Input RECORD + admission layer on
+top of the identity and artifact contracts and is stdlib-only (it depends only on
+:mod:`identity` and :mod:`artifact`, which are themselves stdlib-only).
+
+Design invariants (from the approved+remediated #3430 plan):
+
+- **Six closed input kinds.** ``parameter_set``, ``configuration_document``,
+  ``dataset_snapshot``, ``public_external_resource``, ``upstream_run_reference``,
+  ``artifact_reference``. API-backed inputs are classified as ``dataset_snapshot``
+  (there is NO separate ``api`` kind). Any other kind fails closed.
+- **Snapshot identity excludes fetch-volatile fields.** A dataset input's
+  identity-bearing ``source_snapshot`` digest is derived over EXACTLY
+  ``{source_authority, public_locator, data_as_of, selection, snapshot_identity}``
+  and EXCLUDES ``retrieval_time`` and ``redistribution_evidence`` -- so re-fetching
+  the same pinned snapshot never moves ``run_id`` (see
+  :func:`snapshot_identity_subset`). Canonically-equivalent JSON/YAML/config yield
+  one identity because :mod:`identity` owns canonicalization.
+- **Fail-closed admission.** :func:`admission_reason` returns the FIRST matching
+  contract ``rejection_reason`` (``restricted``, ``pointer_only``,
+  ``ambiguous_license`` -- incl. unknown/absent license, ``mutable_unpinned``,
+  ``unhashed``, ``schema_invalid``, ``incomplete``, ``private``, ``path_leaking``);
+  absolute local paths are forbidden. The OPERATIVE "pinned snapshot" predicate is
+  (``snapshot_identity`` byte-digest present AND versioned ``public_locator``); a
+  ``data_as_of == retrieval_time`` (run-timestamp) case fails because it lacks a
+  snapshot identity -- the missing snapshot is the RULE, timestamp-equality only the
+  symptom.
+- **Replay durability.** A replay-critical input's BYTES must be MATERIALIZED --
+  a content-addressed HF object (via #3429 ``content_digest``) or an embedded
+  ``canonical_repr``. A stable public locator is PROVENANCE, not the reconstruction
+  source; a locator-only replay-critical input is rejected ``pointer_only``.
+- **Identity is minted THROUGH :mod:`identity`.** :func:`input_record_id` maps a
+  record onto identity's seven required ``input_record_id`` components and calls
+  :func:`identity.input_record_id`; :func:`canonical_input_set_digest` calls
+  :func:`identity.input_set_id`. Digests are never re-derived here.
+- **parameter_set vs execution_parameters.** ``parameter_set`` inputs are replay
+  DATA (they flow through the input-set digest); ``execution_parameters`` are
+  run-control knobs (a #3428 ``run_id`` component). A key belongs to exactly one
+  side (:func:`check_no_parameter_double_count`).
+"""
+
+from __future__ import annotations
+
+import re
+
+from assetutilities.workflow_api import artifact, identity
+
+# ---- the six closed input kinds (verbatim from the on-main contract) --------
+INPUT_KINDS = frozenset({
+    "parameter_set",
+    "configuration_document",
+    "dataset_snapshot",
+    "public_external_resource",
+    "upstream_run_reference",
+    "artifact_reference",
+})
+
+# API-backed inputs are classified as dataset_snapshot -- there is no `api` kind.
+_KIND_ALIASES = {"api": "dataset_snapshot"}
+
+# Kinds that pull external public data and must record the source snapshot.
+SNAPSHOT_KINDS = frozenset({"dataset_snapshot", "public_external_resource"})
+# Kinds whose bytes are embedded inline (materialized as their canonical repr).
+EMBEDDED_KINDS = frozenset({"parameter_set", "configuration_document"})
+# Kinds that reference an already-immutable, content-addressed object / run.
+REFERENCE_KINDS = frozenset({"upstream_run_reference", "artifact_reference"})
+
+# allowed_replay_locations (verbatim from public_input_policy).
+ALLOWED_REPLAY_LOCATIONS = frozenset({
+    "content_addressed_dataset_object",
+    "stable_public_uri_with_immutable_digest",
+    "accepted_upstream_public_run",
+})
+
+# rejection_reasons (verbatim from public_input_policy).
+REJECTION_REASONS = frozenset({
+    "restricted",
+    "pointer_only",
+    "ambiguous_license",
+    "mutable_unpinned",
+    "unhashed",
+    "schema_invalid",
+    "incomplete",
+    "private",
+    "path_leaking",
+})
+
+# The five identity-bearing snapshot fields (EXCLUDES retrieval_time +
+# redistribution_evidence, which are fetch-volatile evidence).
+SNAPSHOT_IDENTITY_FIELDS = (
+    "source_authority",
+    "public_locator",
+    "data_as_of",
+    "selection",
+    "snapshot_identity",
+)
+
+# Domain-separation type for the source-snapshot sub-identity.
+SOURCE_SNAPSHOT_ID_TYPE = "input_source_snapshot"
+
+# redistribution_rights tokens that are non-redistributable -> `restricted`.
+_RESTRICTED_RIGHTS = frozenset(
+    {"restricted", "non_redistributable", "client_specific", "forbidden"}
+)
+# redistribution_rights tokens that are ambiguous/unknown -> `ambiguous_license`.
+_AMBIGUOUS_RIGHTS = frozenset({"ambiguous", "unknown", ""})
+
+
+class InputError(ValueError):
+    """Raised when an input record violates the replayable-input contract."""
+
+
+class AdmissionError(InputError):
+    """Raised (fail-closed) when an input is not admissible. Carries ``reason``."""
+
+    def __init__(self, reason: str, message: str | None = None):
+        self.reason = reason
+        super().__init__(message or f"input rejected: {reason}")
+
+
+# ---------------------------------------------------------------------------
+# kind classification (closed enum)
+# ---------------------------------------------------------------------------
+
+def classify_kind(kind) -> str:
+    """Return the canonical input kind, mapping ``api`` -> ``dataset_snapshot``.
+
+    Raises :class:`InputError` for any kind outside the six closed kinds.
+    """
+    canonical = _KIND_ALIASES.get(kind, kind)
+    if canonical not in INPUT_KINDS:
+        raise InputError(
+            f"unknown input kind {kind!r}; the closed set is {sorted(INPUT_KINDS)}"
+        )
+    return canonical
+
+
+# ---------------------------------------------------------------------------
+# record construction
+# ---------------------------------------------------------------------------
+
+def make_input(
+    *,
+    kind,
+    role,
+    schema_version,
+    required_for_replay=True,
+    canonical_repr=None,
+    content_digest=None,
+    replay_location=None,
+    redistribution_rights=None,
+    redistribution_evidence=None,
+    residency="public",
+    transformation_id="identity",
+    # dataset/snapshot provenance:
+    source_authority=None,
+    public_locator=None,
+    data_as_of=None,
+    retrieval_time=None,
+    selection=None,
+    snapshot_identity=None,
+) -> dict:
+    """Build an Input record (classifying ``kind``); admission is applied lazily.
+
+    ``kind`` is validated against the six closed kinds (``api`` ->
+    ``dataset_snapshot``). Every other field is stored verbatim; identity is
+    minted later via :func:`input_record_id` and durability/rights are enforced by
+    :func:`admit`. Embedded kinds default ``redistribution_rights`` to ``owned``.
+    """
+    kind = classify_kind(kind)
+    if kind in EMBEDDED_KINDS and redistribution_rights is None:
+        redistribution_rights = "owned"
+    return {
+        "kind": kind,
+        "role": role,
+        "schema_version": schema_version,
+        "required_for_replay": required_for_replay,
+        "canonical_repr": canonical_repr,
+        "content_digest": content_digest,
+        "replay_location": replay_location,
+        "redistribution_rights": redistribution_rights,
+        "redistribution_evidence": redistribution_evidence,
+        "residency": residency,
+        "transformation_id": transformation_id,
+        "source_authority": source_authority,
+        "public_locator": public_locator,
+        "data_as_of": data_as_of,
+        "retrieval_time": retrieval_time,
+        "selection": selection,
+        "snapshot_identity": snapshot_identity,
+    }
+
+
+# ---------------------------------------------------------------------------
+# path-leak detection (absolute local paths forbidden)
+# ---------------------------------------------------------------------------
+
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _is_abs_local_path(value) -> bool:
+    """True if ``value`` is (or embeds) an absolute local / home / UNC path.
+
+    A proper remote URL (``https://``, ``s3://``, ``hf://`` ...) is NOT a leak; a
+    ``file:`` URI, a ``/``- or ``~``-rooted path, a backslash/UNC path or a Windows
+    drive path IS.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    if value.startswith("file:"):
+        return True
+    if "://" in value:
+        return False  # a non-file remote URL scheme
+    if value.startswith("/") or value.startswith("~"):
+        return True
+    if "\\" in value:
+        return True
+    if _WIN_DRIVE_RE.match(value):
+        return True
+    return False
+
+
+def _iter_strings(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_strings(v)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            yield from _iter_strings(v)
+
+
+def _has_path_leak(rec) -> bool:
+    for field in ("public_locator", "canonical_repr", "selection",
+                  "source_authority", "replay_location"):
+        for text in _iter_strings(rec.get(field)):
+            if _is_abs_local_path(text):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# snapshot / materialization predicates
+# ---------------------------------------------------------------------------
+
+def _locator_uri(locator):
+    if isinstance(locator, dict):
+        return locator.get("uri")
+    return locator
+
+
+def _locator_versioned(locator) -> bool:
+    """A public locator is versioned/immutable when it pins a version or digest."""
+    if isinstance(locator, dict):
+        return bool(locator.get("version") or locator.get("immutable_digest"))
+    if isinstance(locator, str):
+        return "@" in locator  # e.g. "hf://ds/wells@sha256:..."
+    return False
+
+
+def _snapshot_pinned(rec) -> bool:
+    """OPERATIVE pinned-snapshot predicate: byte snapshot identity AND versioned locator."""
+    return bool(rec.get("snapshot_identity")) and _locator_versioned(rec.get("public_locator"))
+
+
+def _content_hash(rec):
+    """The record's content hash: content_digest, embedded-repr digest, or snapshot id.
+
+    An artifact ``content_digest`` (via #3429) or an embedded ``canonical_repr``
+    (hashed through :func:`artifact.structured_object_digest`, reusing the single
+    canonicalization owner) is a materialized byte hash; a bare ``snapshot_identity``
+    is a locator/provenance hash (not materialized bytes).
+    """
+    if rec.get("content_digest"):
+        return rec["content_digest"]
+    if rec.get("canonical_repr") is not None:
+        return artifact.structured_object_digest(rec["canonical_repr"])
+    if rec.get("snapshot_identity"):
+        return rec["snapshot_identity"]
+    return None
+
+
+def _materialized(rec) -> bool:
+    """Replay bytes are materialized (content-addressed HF object or embedded repr)."""
+    return bool(rec.get("content_digest")) or rec.get("canonical_repr") is not None
+
+
+# ---------------------------------------------------------------------------
+# fail-closed admission
+# ---------------------------------------------------------------------------
+
+def admission_reason(rec) -> str | None:
+    """Return the FIRST contract ``rejection_reason`` for ``rec``, or ``None`` if admissible.
+
+    Fail-closed: order is deterministic so each rejection has a single stable reason.
+    """
+    kind = rec["kind"]
+    rights = rec.get("redistribution_rights")
+
+    if _has_path_leak(rec):
+        return "path_leaking"
+
+    schema_version = rec.get("schema_version")
+    if not schema_version or not isinstance(schema_version, str):
+        return "schema_invalid"
+
+    if rec.get("residency") == "private":
+        return "private"
+
+    if rights in _RESTRICTED_RIGHTS:
+        return "restricted"
+    if rights is None or rights in _AMBIGUOUS_RIGHTS:
+        return "ambiguous_license"
+
+    # external public snapshots must be pinned to an immutable byte-snapshot.
+    if kind in SNAPSHOT_KINDS and not _snapshot_pinned(rec):
+        return "mutable_unpinned"
+
+    if _content_hash(rec) is None:
+        return "unhashed"
+
+    # replay-critical bytes must be MATERIALIZED; a locator alone is provenance.
+    if rec.get("required_for_replay", True) and not _materialized(rec):
+        return "pointer_only"
+
+    if rec.get("replay_location") not in ALLOWED_REPLAY_LOCATIONS:
+        return "incomplete"
+    if kind in SNAPSHOT_KINDS and not (rec.get("source_authority") and rec.get("data_as_of")):
+        return "incomplete"
+    return None
+
+
+def admit(rec) -> dict:
+    """Return ``rec`` if admissible, else raise :class:`AdmissionError` (fail-closed)."""
+    reason = admission_reason(rec)
+    if reason is not None:
+        raise AdmissionError(reason, f"input {rec.get('kind')!r} rejected: {reason}")
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# snapshot identity + record/set identity (minted THROUGH the identity module)
+# ---------------------------------------------------------------------------
+
+def snapshot_identity_subset(rec) -> dict:
+    """The identity-bearing snapshot subset (EXCLUDES retrieval_time + evidence)."""
+    return {field: rec.get(field) for field in SNAPSHOT_IDENTITY_FIELDS}
+
+
+def _source_snapshot_token(rec) -> str:
+    """The ``source_snapshot`` identity component for a record.
+
+    For snapshot kinds this is the domain-separated digest of the identity-bearing
+    subset (via :func:`identity.canonical_digest`); for reference/embedded kinds the
+    materialized content hash IS the source.
+    """
+    if rec["kind"] in SNAPSHOT_KINDS:
+        return identity.canonical_digest(SOURCE_SNAPSHOT_ID_TYPE, snapshot_identity_subset(rec))
+    return _content_hash(rec)
+
+
+def _record_components(rec) -> dict:
+    """Map an admitted record onto identity's seven ``input_record_id`` components."""
+    return {
+        "role": rec["role"],
+        "native_schema_version": rec["schema_version"],
+        "source_snapshot": _source_snapshot_token(rec),
+        "transformation_id": rec.get("transformation_id") or "identity",
+        "artifact_sha256": _content_hash(rec),
+        "redistribution_rights": rec["redistribution_rights"],
+        "complete_replay_location": rec["replay_location"],
+    }
+
+
+def input_record_id(rec) -> str:
+    """Admit ``rec`` then mint its ``input_record_id`` via :func:`identity.input_record_id`."""
+    admit(rec)
+    return identity.input_record_id(_record_components(rec))
+
+
+def canonical_input_set_digest(records) -> str:
+    """Admit every record and mint the ``input_set_id`` over ``(role, input_record_id)``.
+
+    Delegates to :func:`identity.input_set_id`, which sorts pairs so the set identity
+    is order-independent. Canonically-equivalent inputs collapse to one identity.
+    """
+    pairs = [(rec["role"], input_record_id(rec)) for rec in records]
+    return identity.input_set_id(pairs)
+
+
+# ---------------------------------------------------------------------------
+# parameter_set vs execution_parameters (cross-plan with #3428)
+# ---------------------------------------------------------------------------
+
+def check_no_parameter_double_count(parameter_set_records, execution_parameters) -> bool:
+    """Assert no key is BOTH a parameter_set input and an execution_parameter.
+
+    ``parameter_set`` inputs are replay DATA (they flow through the input-set digest);
+    ``execution_parameters`` are #3428 run-control knobs. A key belongs to exactly one
+    side; an overlap raises :class:`InputError`.
+    """
+    param_keys: set = set()
+    for rec in parameter_set_records:
+        if rec.get("kind") != "parameter_set":
+            continue
+        repr_ = rec.get("canonical_repr")
+        if isinstance(repr_, dict):
+            param_keys |= set(repr_)
+    overlap = param_keys & set(execution_parameters or {})
+    if overlap:
+        raise InputError(
+            "keys counted on BOTH the parameter_set (replay data) and "
+            f"execution_parameters (run-control) sides: {sorted(overlap)}"
+        )
+    return True

--- a/tests/workflow_api/test_artifact.py
+++ b/tests/workflow_api/test_artifact.py
@@ -318,3 +318,16 @@ def test_eligibility_is_byte_license_times_reference_role():
     assert "eligible" not in public_art and "class" not in public_art
     assert artifact.RESIDENCY_CONTRACT == "content_addressed_hf_object_or_explicit_exclusion"
     assert artifact.DATASET_TABLE == "artifacts"
+
+
+def test_structured_content_digest_is_plain_hash_of_stored_bytes():
+    # A content_digest is a CONTENT ADDRESS: it must equal a plain sha256 of the
+    # exact bytes the object store persists, so workspace-hub#3433's uniform
+    # object-store re-hash can revalidate a structured artifact without knowing
+    # its type. Domain separation (an identity concern) must NOT leak in here.
+    obj = {"b": 2, "a": 1}
+    stored = artifact.structured_stored_bytes(obj)
+    assert artifact.structured_object_digest(obj) == hashlib.sha256(stored).hexdigest()
+    # and it round-trips through verify_integrity as a physical re-hash of stored bytes
+    rec = artifact.structured_artifact(obj, media_type="application/json", native_format="jcs")
+    assert artifact.verify_integrity(rec, stored_bytes=stored) is True

--- a/tests/workflow_api/test_artifact.py
+++ b/tests/workflow_api/test_artifact.py
@@ -1,0 +1,320 @@
+# ABOUTME: TDD tests for the content-addressed artifact + HF-residency contract
+# ABOUTME: (workspace-hub#3429): physical-byte vs structured digests, role-free identity,
+# ABOUTME: integrity-from-bytes, storage-locator safety, and projection-time residency.
+"""Artifact contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``artifact`` record
+(``identity: content_digest``, ``residency:
+content_addressed_hf_object_or_explicit_exclusion``, ``dataset_table: artifacts``):
+
+- content_digest is SHA-256 of the EXACT STORED bytes (physical) or of the
+  ``identity.canonicalize`` JCS form (structured object). Compression is purely
+  descriptive metadata and NEVER triggers decode-before-hash.
+- The Artifact record is role-free / byte-intrinsic: identical bytes -> one record
+  regardless of how many runs/roles reference it. Residency ``class``/role/
+  ``eligible`` never live on the record.
+- Integrity is re-validated from the object's actual bytes; a manifest-asserted
+  digest that disagrees is rejected (bytes win, manifest is untrusted).
+- storage_locator must be shard-sharded + tied to the record digest and reject
+  path-leaking locators.
+- Residency eligibility is computed at projection time as (byte-intrinsic license
+  evidence) x (per-reference role); a dataset-level license can never grant rights
+  absent from the artifact's own ``license_evidence_ref``. Excluded roles get a
+  VISIBLE ``class: excluded`` marker, never silent omission.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+
+import pytest
+
+from assetutilities.workflow_api import artifact, identity
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _sha256(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def _public_license() -> dict:
+    return {"redistribution": "public", "license": "CC-BY-4.0"}
+
+
+# ---------------------------------------------------------------------------
+# 1. physical artifact hashes the stored bytes, never the decoded bytes
+# ---------------------------------------------------------------------------
+
+def test_physical_artifact_hashes_stored_bytes_not_decoded():
+    decoded = b"replay-critical payload" * 64
+    stored = gzip.compress(decoded)
+    assert stored != decoded
+
+    art = artifact.physical_artifact(
+        stored, media_type="application/octet-stream",
+        native_format="ndjson", compression="gzip",
+    )
+
+    # TRUE content addressing: digest is over the exact immutable STORED bytes.
+    assert art["content_digest"] == _sha256(stored)
+    assert art["size_bytes"] == len(stored)
+    # compression is PURELY DESCRIPTIVE metadata; it must NOT decode-before-hash.
+    assert art["compression"] == "gzip"
+    assert art["content_digest"] != _sha256(decoded)
+
+    # a publisher re-hashing the exact stored bytes agrees.
+    assert artifact.verify_integrity(art, stored_bytes=stored) is True
+    # re-hashing the DECODED bytes must NOT be accepted as the same object.
+    with pytest.raises(artifact.IntegrityError):
+        artifact.verify_integrity(art, stored_bytes=decoded)
+
+
+# ---------------------------------------------------------------------------
+# 2. structured object uses the canonical (JCS) form
+# ---------------------------------------------------------------------------
+
+def test_structured_object_uses_canonical_form():
+    obj_a = {"b": 1, "a": {"y": 2, "x": 3}}
+    obj_b = {"a": {"x": 3, "y": 2}, "b": 1}  # different key ordering, same object
+
+    d_a = artifact.structured_object_digest(obj_a)
+    d_b = artifact.structured_object_digest(obj_b)
+    assert d_a == d_b, "two key-orderings of one object must yield one digest"
+
+    # digest is derived through identity.canonicalize (the JCS owner), not raw dict repr.
+    assert identity.canonicalize(obj_a) == identity.canonicalize(obj_b)
+
+    art_a = artifact.structured_artifact(obj_a)
+    art_b = artifact.structured_artifact(obj_b)
+    assert art_a["content_digest"] == art_b["content_digest"] == d_a
+    assert art_a == art_b  # one artifact record regardless of key order
+
+
+# ---------------------------------------------------------------------------
+# 3. identical bytes -> ONE artifact record, no role/residency on the record
+# ---------------------------------------------------------------------------
+
+def test_identical_bytes_one_artifact_record_across_roles():
+    payload = b"shared immutable object bytes"
+    art_seen_as_input = artifact.physical_artifact(
+        payload, media_type="text/csv", native_format="csv")
+    art_seen_as_output = artifact.physical_artifact(
+        payload, media_type="text/csv", native_format="csv")
+
+    # identical bytes -> identical record (deduplicated to one content_digest).
+    assert art_seen_as_input == art_seen_as_output
+    assert art_seen_as_input["content_digest"] == _sha256(payload)
+
+    # the record carries ONLY byte-intrinsic fields; role/residency live elsewhere.
+    for banned in ("class", "role", "eligible", "residency", "residency_class"):
+        assert banned not in art_seen_as_input
+    assert set(art_seen_as_input) == {
+        "content_digest", "size_bytes", "media_type", "native_format",
+        "compression", "schema_ref", "storage_locator", "license_evidence_ref",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. integrity is revalidated from the bytes; a manifest lie is rejected
+# ---------------------------------------------------------------------------
+
+def test_integrity_revalidated_from_bytes_rejects_manifest_lie():
+    payload = b"authentic bytes"
+    art = artifact.physical_artifact(
+        payload, media_type="application/octet-stream", native_format="bin")
+
+    # (a) tampered bytes: the stored bytes changed, the asserted digest no longer holds.
+    with pytest.raises(artifact.IntegrityError):
+        artifact.verify_integrity(art, stored_bytes=b"tampered bytes")
+
+    # (b) a wrong manifest-asserted digest is rejected even for the genuine bytes:
+    # bytes win, the manifest is untrusted.
+    lying = dict(art)
+    lying["content_digest"] = "0" * 64
+    lying["storage_locator"] = artifact.storage_locator_for("0" * 64)
+    with pytest.raises(artifact.IntegrityError):
+        artifact.verify_integrity(lying, stored_bytes=payload)
+
+
+# ---------------------------------------------------------------------------
+# 5. storage_locator must equal objects/<d[:2]>/<d> for the record's own digest
+# ---------------------------------------------------------------------------
+
+def test_storage_locator_matches_record_digest():
+    payload = b"locator bytes"
+    art = artifact.physical_artifact(
+        payload, media_type="application/octet-stream", native_format="bin")
+    d = art["content_digest"]
+    assert art["storage_locator"] == "objects/" + d[:2] + "/" + d
+    assert artifact.validate_storage_locator(art["storage_locator"], d) is True
+
+    # a locator that points at a DIFFERENT digest is rejected.
+    other = "f" * 64
+    with pytest.raises(artifact.StorageLocatorError):
+        artifact.validate_storage_locator("objects/" + other[:2] + "/" + other, d)
+    # right digest but wrong shard prefix is rejected.
+    with pytest.raises(artifact.StorageLocatorError):
+        artifact.validate_storage_locator("objects/zz/" + d, d)
+    # constructing a record with a mismatched supplied locator is rejected.
+    with pytest.raises(artifact.StorageLocatorError):
+        artifact.make_artifact(
+            content_digest=d, size_bytes=len(payload), media_type="x",
+            native_format="bin", storage_locator="objects/00/" + other)
+
+
+# ---------------------------------------------------------------------------
+# 6. unsafe storage locators (absolute / ~ / UNC / ..) are rejected
+# ---------------------------------------------------------------------------
+
+def test_unsafe_storage_locator_rejected():
+    d = _sha256(b"whatever")
+    unsafe = [
+        "/etc/passwd",                       # absolute
+        "/objects/" + d[:2] + "/" + d,       # absolute even if otherwise shaped
+        "~/objects/" + d[:2] + "/" + d,      # home
+        "~root/secret",                      # home
+        "\\\\server\\share\\" + d,           # UNC
+        "C:\\objects\\" + d,                 # windows drive / backslash
+        "objects/../" + d[:2] + "/" + d,     # parent traversal
+        "objects/" + d[:2] + "/../" + d,     # parent traversal
+    ]
+    for loc in unsafe:
+        with pytest.raises(artifact.StorageLocatorError):
+            artifact.validate_storage_locator(loc, d)
+
+
+# ---------------------------------------------------------------------------
+# 7. restricted / ambiguous / client-specific / path-leak / non-redist FAIL
+# ---------------------------------------------------------------------------
+
+def test_restricted_ambiguous_client_pathleak_nonredist_fail_projection():
+    payload = b"sensitive object"
+    role = "curated_native_output"  # an otherwise HF-eligible role
+
+    failing_licenses = {
+        "restricted": {"redistribution": "restricted", "license": "MIT"},
+        "ambiguous": {"redistribution": "public", "license": "ambiguous"},
+        "client_specific": {"redistribution": "client_specific", "license": "MIT"},
+        "path_leak": {"redistribution": "public", "license": "MIT",
+                       "evidence_path": "/home/vamsee/client/LICENSE.txt"},
+        "non_redistributable": {"redistribution": "non_redistributable", "license": "MIT"},
+    }
+    for label, lic in failing_licenses.items():
+        art = artifact.physical_artifact(
+            payload, media_type="text/plain", native_format="txt",
+            license_evidence_ref=lic)
+        proj = artifact.project_reference_residency(art, role)
+        assert proj["class"] == artifact.CLASS_EXCLUDED, f"{label} must fail projection"
+        assert proj["reason"], "an excluded projection must carry a visible reason"
+
+
+# ---------------------------------------------------------------------------
+# 8. transient/cache/regenerable roles are VISIBLY excluded, not silently dropped
+# ---------------------------------------------------------------------------
+
+def test_excluded_roles_are_visibly_excluded():
+    payload = b"regenerable dump"
+    # a perfectly public license does NOT rescue a transient/regenerable role.
+    art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="log",
+        license_evidence_ref=_public_license())
+
+    for role in ("transient_log", "cache", "large_regenerable_dump"):
+        proj = artifact.project_reference_residency(art, role)
+        assert proj is not None, "exclusion must be an explicit marker, not silent omission"
+        assert proj["class"] == artifact.CLASS_EXCLUDED
+        assert role in proj["reason"]
+        assert proj["content_digest"] == art["content_digest"]
+
+
+# ---------------------------------------------------------------------------
+# 9. a dataset-level license can NOT grant rights the artifact itself lacks
+# ---------------------------------------------------------------------------
+
+def test_dataset_license_cannot_grant_missing_rights():
+    payload = b"no license evidence on this object"
+    art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="txt",
+        license_evidence_ref=None)  # NO byte-intrinsic license evidence
+
+    dataset_license = {"redistribution": "public", "license": "CC-BY-4.0"}
+    proj = artifact.project_reference_residency(
+        art, "curated_native_output", dataset_license=dataset_license)
+    assert proj["class"] == artifact.CLASS_EXCLUDED, (
+        "a dataset-level license must never grant rights absent from the "
+        "artifact's own license_evidence_ref")
+
+
+# ---------------------------------------------------------------------------
+# 10. an input reference and an output reference share ONE artifact, no dup
+# ---------------------------------------------------------------------------
+
+def test_input_and_output_reference_same_artifact_without_duplication():
+    obj = {"grid": [1, 2, 3], "coeff": 0.5}
+    art = artifact.structured_artifact(obj, license_evidence_ref=_public_license())
+
+    # referenced as a replay-critical input in run A and a curated output in run B:
+    # both point at the SAME content_digest; the record is identical (no role on it).
+    as_input = artifact.project_reference_residency(art, "replay_critical_input")
+    as_output = artifact.project_reference_residency(art, "curated_native_output")
+    assert as_input["content_digest"] == as_output["content_digest"] == art["content_digest"]
+    assert as_input["class"] == as_output["class"] == artifact.CLASS_HF_OBJECT
+    # the artifact record itself is unchanged by projection (role lives on the reference).
+    assert "role" not in art and "class" not in art
+
+
+# ---------------------------------------------------------------------------
+# 11. a dedicated forbidden-residency fixture is rejected at construction
+# ---------------------------------------------------------------------------
+
+def test_forbidden_residency_fixture_rejected():
+    payload = b"attempt to stamp residency onto the record"
+    d = _sha256(payload)
+    # stamping residency/role/eligibility onto the byte-intrinsic record is forbidden.
+    for forbidden_field in ("residency", "class", "role", "eligible"):
+        with pytest.raises(artifact.ArtifactError):
+            artifact.make_artifact(
+                content_digest=d, size_bytes=len(payload), media_type="x",
+                native_format="bin", **{forbidden_field: "excluded"})
+
+    # a fixture whose license is explicitly a forbidden residency also fails projection.
+    art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="txt",
+        license_evidence_ref={"redistribution": "forbidden", "license": "MIT"})
+    proj = artifact.project_reference_residency(art, "curated_native_output")
+    assert proj["class"] == artifact.CLASS_EXCLUDED
+
+
+# ---------------------------------------------------------------------------
+# 12. eligibility == (byte-license) x (reference-role), computed at projection
+# ---------------------------------------------------------------------------
+
+def test_eligibility_is_byte_license_times_reference_role():
+    payload = b"one object, many references"
+
+    public_art = artifact.physical_artifact(
+        payload, media_type="text/plain", native_format="txt",
+        license_evidence_ref=_public_license())
+    restricted_art = artifact.physical_artifact(
+        payload + b"x", media_type="text/plain", native_format="txt",
+        license_evidence_ref={"redistribution": "restricted", "license": "MIT"})
+
+    # public license x eligible role -> HF object
+    assert artifact.project_reference_residency(
+        public_art, "curated_native_output")["class"] == artifact.CLASS_HF_OBJECT
+    # public license x excluded role -> excluded (role gate)
+    assert artifact.project_reference_residency(
+        public_art, "cache")["class"] == artifact.CLASS_EXCLUDED
+    # restricted license x eligible role -> excluded (license gate)
+    assert artifact.project_reference_residency(
+        restricted_art, "curated_native_output")["class"] == artifact.CLASS_EXCLUDED
+
+    # the product is computed at projection time, NOT stamped on the record.
+    assert "eligible" not in public_art and "class" not in public_art
+    assert artifact.RESIDENCY_CONTRACT == "content_addressed_hf_object_or_explicit_exclusion"
+    assert artifact.DATASET_TABLE == "artifacts"

--- a/tests/workflow_api/test_identity.py
+++ b/tests/workflow_api/test_identity.py
@@ -1,0 +1,411 @@
+# ABOUTME: TDD tests for the deterministic run-identity contract (workspace-hub#3428):
+# ABOUTME: canonical serialization, domain-separated digests, and identity derivation.
+"""Identity contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``identity`` block:
+canonical serialization owned here, SHA-256 digests domain-separated by id type,
+each id binds exactly its declared required components (and rejects the forbidden
+ones), and identity is fail-closed / re-derivable from a verified clean context.
+"""
+
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+
+import pytest
+
+from assetutilities.workflow_api import identity
+
+
+# ---------------------------------------------------------------------------
+# shared fixtures / builders
+# ---------------------------------------------------------------------------
+
+def _avid(**overrides) -> str:
+    kwargs = dict(
+        algorithm_id="stress_screen",
+        semantic_version="1.4.2",
+        clean_git_commit="a" * 40,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-" + "b" * 8,
+    )
+    kwargs.update(overrides)
+    return identity.algorithm_version_id(**kwargs)
+
+
+def _input_record(**overrides) -> dict:
+    rec = dict(
+        role="primary",
+        native_schema_version="ns-1",
+        source_snapshot="snap-2026-07-01",
+        transformation_id="xf-9",
+        artifact_sha256="c" * 64,
+        redistribution_rights="internal",
+        complete_replay_location="s3://bucket/replay/1",
+    )
+    rec.update(overrides)
+    return rec
+
+
+def _derive(**overrides):
+    kwargs = dict(
+        algorithm_id="stress_screen",
+        semantic_version="1.4.2",
+        clean_git_commit="a" * 40,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-" + "b" * 8,
+        inputs=[("primary", "irid-1"), ("aux", "irid-2")],
+        execution_parameters={"tolerance": "1e-6", "mode": "fast"},
+        seed=1234,
+    )
+    kwargs.update(overrides)
+    return identity.derive_run_identity(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. algorithm_version_id binds all required components
+# ---------------------------------------------------------------------------
+
+def test_algorithm_version_id_binds_all_components():
+    base = _avid()
+    changes = {
+        "algorithm_id": "other_algo",
+        "semantic_version": "1.4.3",
+        "clean_git_commit": "d" * 40,
+        "input_schema_version": "in-4",
+        "output_schema_version": "out-3",
+        "environment_digest": "env-" + "e" * 8,
+    }
+    ids = {base}
+    for comp, newval in changes.items():
+        variant = _avid(**{comp: newval})
+        assert variant != base, f"changing {comp} must change algorithm_version_id"
+        ids.add(variant)
+    # every single-component change produced a distinct id
+    assert len(ids) == len(changes) + 1
+
+    # a missing/None required component is rejected (fail-closed), never hashed as absent
+    with pytest.raises(identity.IdentityError):
+        _avid(environment_digest=None)
+
+
+# ---------------------------------------------------------------------------
+# 2. run_id binds its components, excludes outputs, uses input_set_id
+# ---------------------------------------------------------------------------
+
+def test_run_id_binds_components_excludes_outputs():
+    avid = _avid()
+    isid = identity.input_set_id([("primary", "irid-1")])
+    rid = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters={"mode": "fast"},
+        seed=7,
+    )
+    # run_id has no output channel at all -> an output change cannot move it.
+    rid_again = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=isid,
+        execution_parameters={"mode": "fast"},
+        seed=7,
+    )
+    assert rid == rid_again
+
+    # each real component is bound
+    assert rid != identity.run_id(
+        algorithm_version_id=_avid(algorithm_id="x"),
+        input_set_id=isid, execution_parameters={"mode": "fast"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=identity.input_set_id([("primary", "irid-2")]),
+        execution_parameters={"mode": "fast"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid, input_set_id=isid,
+        execution_parameters={"mode": "slow"}, seed=7)
+    assert rid != identity.run_id(
+        algorithm_version_id=avid, input_set_id=isid,
+        execution_parameters={"mode": "fast"}, seed=8)
+
+
+# ---------------------------------------------------------------------------
+# 3. canonicalization: equivalent values -> same digest
+# ---------------------------------------------------------------------------
+
+def test_canonicalization_equivalent_values_same_digest():
+    # (a) JCS: object key order + insignificant whitespace are irrelevant.
+    a = {"b": 1, "a": {"y": 2, "x": 3}}
+    b = {"a": {"x": 3, "y": 2}, "b": 1}
+    assert identity.canonicalize(a) == identity.canonicalize(b)
+    assert identity.canonical_digest("t", a) == identity.canonical_digest("t", b)
+
+    # (b) numbers normalize via Decimal, no float round-trip.
+    assert identity.canonicalize(1e3) == identity.canonicalize(1000)
+    assert identity.canonicalize(1000) == identity.canonicalize(Decimal("1E3"))
+    assert identity.canonicalize(5.0) == identity.canonicalize(5)
+    assert identity.canonicalize(5.00) == identity.canonicalize(Decimal("5.00"))
+    assert identity.canonicalize(5) == identity.canonicalize(Decimal("5.00"))
+
+    # (c) Unicode NFC vs NFD forms collapse before hashing.
+    nfc = "é"          # é  (composed)
+    nfd = "é"         # e + combining acute (decomposed)
+    assert nfc != nfd
+    assert identity.canonicalize(nfc) == identity.canonicalize(nfd)
+
+    # (d) a physical quantity MUST be an explicit {value, unit} pair; a bare
+    # units-bearing numeric string is rejected.
+    with pytest.raises(identity.IdentityError):
+        identity.canonicalize("5 kg")
+    with pytest.raises(identity.IdentityError):
+        identity.canonicalize({"mass": "5.0m"})
+    # the explicit pair is accepted
+    identity.canonicalize({"mass": {"value": 5.0, "unit": "kg"}})
+
+
+# ---------------------------------------------------------------------------
+# 4. different inputs never collide (incl. near-collision)
+# ---------------------------------------------------------------------------
+
+def test_different_inputs_never_collide():
+    assert identity.canonical_digest("t", {"v": 1.0}) != identity.canonical_digest(
+        "t", {"v": 1.0000000001})
+    assert identity.canonical_digest("t", [1, 2]) != identity.canonical_digest(
+        "t", [2, 1])  # arrays are ordered
+    assert identity.canonical_digest("t", {"a": 1}) != identity.canonical_digest(
+        "t", {"a": 1, "b": None})  # explicit null is a real difference, not omitted
+
+
+# ---------------------------------------------------------------------------
+# 5. domain separation prevents cross-type collision
+# ---------------------------------------------------------------------------
+
+def test_domain_separation_prevents_cross_type_collision():
+    components = {"role": "primary", "x": 1}
+    a = identity.canonical_digest("algorithm_version_id", components)
+    b = identity.canonical_digest("input_record_id", components)
+    c = identity.canonical_digest("run_id", components)
+    assert len({a, b, c}) == 3, "same bytes under different id types must not collide"
+    # and equal type + equal bytes DO agree (determinism)
+    assert a == identity.canonical_digest("algorithm_version_id", dict(components))
+
+
+# ---------------------------------------------------------------------------
+# 6. canonicalization_version is in every digest and pins the scheme
+# ---------------------------------------------------------------------------
+
+def test_canonicalization_version_in_digests_and_pins_scheme(monkeypatch):
+    before = identity.canonical_digest("t", {"a": 1})
+    assert isinstance(identity.CANONICALIZATION_VERSION, str)
+    monkeypatch.setattr(identity, "CANONICALIZATION_VERSION", "identity-jcs-999")
+    after = identity.canonical_digest("t", {"a": 1})
+    assert before != after, "bumping the scheme version must mint new ids deterministically"
+
+
+# ---------------------------------------------------------------------------
+# 7. fail-closed eligibility
+# ---------------------------------------------------------------------------
+
+def _eligible(**overrides):
+    kwargs = dict(
+        clean_tree=True,
+        commit="a" * 40,
+        commit_known=True,
+        input_schema_version="in-3",
+        output_schema_version="out-2",
+        environment_digest="env-1",
+        seed=0,
+        execution_parameters={},
+    )
+    kwargs.update(overrides)
+    return identity.check_eligibility(**kwargs)
+
+
+def test_dirty_or_unpinned_or_implicit_seed_fails_closed():
+    # baseline is eligible
+    assert _eligible() is True
+
+    reject_cases = [
+        dict(clean_tree=False),                       # dirty_source
+        dict(commit_known=False),                     # unknown_revision (shallow/unknown)
+        dict(commit=None),                            # unknown_revision (no commit)
+        dict(input_schema_version=None),              # unpinned_schema
+        dict(output_schema_version=None),             # unpinned_schema
+        dict(environment_digest=None),                # missing_environment_digest
+        dict(seed=None),                              # implicit_seed
+        dict(execution_parameters=None),              # implicit_execution_default
+    ]
+    for case in reject_cases:
+        with pytest.raises(identity.EligibilityError):
+            _eligible(**case)
+
+    # seed == 0 is EXPLICIT (must not be treated as implicit)
+    assert _eligible(seed=0) is True
+
+
+# ---------------------------------------------------------------------------
+# 8. same canonical inputs -> same run_id across machines
+# ---------------------------------------------------------------------------
+
+def test_same_canonical_inputs_same_run_id_cross_machine(monkeypatch, tmp_path):
+    a = _derive()
+    # simulate a different machine: different cwd + different environment
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOSTNAME", "machine-b")
+    monkeypatch.setenv("PWD", str(tmp_path))
+    monkeypatch.setenv("USER", "someone-else")
+    b = _derive()
+    assert a["run_id"] == b["run_id"]
+    assert a["algorithm_version_id"] == b["algorithm_version_id"]
+    assert a["input_set_id"] == b["input_set_id"]
+
+
+# ---------------------------------------------------------------------------
+# 9. any component change changes identity
+# ---------------------------------------------------------------------------
+
+def test_any_component_change_changes_identity():
+    base = _derive()["run_id"]
+    assert _derive(semantic_version="9.9.9")["run_id"] != base
+    assert _derive(clean_git_commit="f" * 40)["run_id"] != base
+    assert _derive(environment_digest="env-other")["run_id"] != base
+    assert _derive(inputs=[("primary", "irid-1"), ("aux", "irid-CHANGED")])["run_id"] != base
+    assert _derive(execution_parameters={"tolerance": "1e-6", "mode": "slow"})["run_id"] != base
+    assert _derive(seed=4321)["run_id"] != base
+
+
+# ---------------------------------------------------------------------------
+# 10. execution_parameters vs parameter_set are not double-counted
+# ---------------------------------------------------------------------------
+
+def test_execution_parameter_and_parameter_set_not_double_counted():
+    # input_set_id depends ONLY on the input records, never on execution_parameters.
+    isid_a = identity.input_set_id([("primary", "irid-1")])
+    isid_b = identity.input_set_id([("primary", "irid-1")])
+    assert isid_a == isid_b
+
+    # A knob living on the execution side moves run_id but NOT input_set_id.
+    r1 = _derive(execution_parameters={"knob": "A"})
+    r2 = _derive(execution_parameters={"knob": "B"})
+    assert r1["input_set_id"] == r2["input_set_id"]   # not leaking into the input side
+    assert r1["run_id"] != r2["run_id"]
+
+    # The same logical value expressed on the INPUT side (a different input record)
+    # moves input_set_id (and run_id) but leaves execution_parameters untouched --
+    # i.e. it is counted on exactly one side, never both.
+    r3 = _derive(inputs=[("primary", "irid-knobA")], execution_parameters={})
+    r4 = _derive(inputs=[("primary", "irid-knobB")], execution_parameters={})
+    assert r3["input_set_id"] != r4["input_set_id"]
+    assert r3["run_id"] != r4["run_id"]
+
+
+# ---------------------------------------------------------------------------
+# 11. run_id uses an opaque injected input_set_id (no #3430 dependency)
+# ---------------------------------------------------------------------------
+
+def test_run_id_uses_opaque_injected_input_set_digest():
+    avid = _avid()
+    opaque = "0" * 64  # a stand-in input_set_id we did not compute here
+    rid = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id=opaque,
+        execution_parameters={"mode": "fast"},
+        seed=1,
+    )
+    assert isinstance(rid, str) and len(rid) == 64
+    # a different opaque digest yields a different run_id, with no knowledge of
+    # how the input_set_id was constructed (that is #3430's concern).
+    rid2 = identity.run_id(
+        algorithm_version_id=avid,
+        input_set_id="1" * 64,
+        execution_parameters={"mode": "fast"},
+        seed=1,
+    )
+    assert rid != rid2
+
+
+# ---------------------------------------------------------------------------
+# 12. exact-rerun output mismatch fails closed without mutation
+# ---------------------------------------------------------------------------
+
+def test_exact_rerun_output_mismatch_fails_closed_no_mutation():
+    assert identity.OUTPUT_EQUALITY_DEFAULT == "raw_bytes_sha256"
+    prior = {"run_id": "r1", "output_equality_digest": "aa" * 32, "published": True}
+
+    # equal digests -> accepted (no exception)
+    identity.assert_output_equality(prior["output_equality_digest"], "aa" * 32)
+
+    # mismatch -> reject WITHOUT mutating the prior record
+    snapshot = dict(prior)
+    with pytest.raises(identity.OutputMismatchError):
+        identity.assert_output_equality(
+            prior["output_equality_digest"], "bb" * 32, prior_record=prior)
+    assert prior == snapshot, "reject_without_mutation: prior state must be untouched"
+
+
+# ---------------------------------------------------------------------------
+# 13. terminal statuses carry run_id; indeterminate mints none
+# ---------------------------------------------------------------------------
+
+def test_terminal_statuses_have_no_attempt_identity():
+    rid = _derive()["run_id"]
+    assert identity.mints_identity("succeeded") is True
+    assert identity.mints_identity("reproducible_failure") is True
+    assert identity.mints_identity("indeterminate_failure") is False
+
+    assert identity.run_identity_for_status("succeeded", rid) == rid
+    assert identity.run_identity_for_status("reproducible_failure", rid) == rid
+    # non-terminal, non-identity-bearing -> mints NO identity (attempts/retries never do)
+    assert identity.run_identity_for_status("indeterminate_failure", rid) is None
+
+
+# ---------------------------------------------------------------------------
+# 14. input_record_id forbids run-scoped and PII components
+# ---------------------------------------------------------------------------
+
+def test_input_record_id_forbids_run_scoped_and_pii_components():
+    good = identity.input_record_id(_input_record())
+    assert isinstance(good, str) and len(good) == 64
+
+    forbidden_examples = [
+        "run_id", "algorithm_version_id", "output_set_id", "attempt_id",
+        "retry_count", "publication_state", "tenant_id", "customer_id",
+        "request_id", "session_id", "user_id",
+    ]
+    for bad_key in forbidden_examples:
+        rec = _input_record(**{bad_key: "leak"})
+        with pytest.raises(identity.IdentityError):
+            identity.input_record_id(rec)
+
+    # a missing required component is likewise rejected (fail-closed)
+    incomplete = _input_record()
+    del incomplete["artifact_sha256"]
+    with pytest.raises(identity.IdentityError):
+        identity.input_record_id(incomplete)
+
+
+# ---------------------------------------------------------------------------
+# 15. envelope hashes are evidence, never identity inputs
+# ---------------------------------------------------------------------------
+
+def test_envelope_hashes_are_evidence_not_identity():
+    # The identity-derivation entrypoint deliberately consumes NEITHER the
+    # envelope input_hash NOR the best-effort code_version git_sha.
+    params = set(inspect.signature(identity.derive_run_identity).parameters)
+    assert "input_hash" not in params
+    assert "git_sha" not in params
+    for p in params:
+        assert "input_hash" not in p and "git_sha" not in p and "envelope" not in p
+
+    # Concretely: two runs whose ONLY difference is fabricated envelope evidence
+    # (a different volatile input_hash / best-effort git_sha) share one run_id,
+    # because that evidence is never passed into identity.
+    a = _derive()
+    _evidence_a = {"input_hash": "deadbeef", "git_sha": "1111111"}  # noqa: F841 -- not consumed
+    b = _derive()
+    _evidence_b = {"input_hash": "cafef00d", "git_sha": "2222222"}  # noqa: F841 -- not consumed
+    assert a["run_id"] == b["run_id"]
+    # identity is bound to the VERIFIED clean commit, not the best-effort sha
+    assert a["algorithm_version_id"] == b["algorithm_version_id"]

--- a/tests/workflow_api/test_inputs.py
+++ b/tests/workflow_api/test_inputs.py
@@ -1,0 +1,305 @@
+# ABOUTME: TDD tests for the replayable public-input + source-snapshot contract
+# ABOUTME: (workspace-hub#3430): six closed input kinds, fail-closed admission, snapshot identity.
+"""Replayable-input contract tests (no engine dependency).
+
+These pin the normative rules from the on-main
+``docs/architecture/algorithm-run-dataset-contract.yaml`` ``records.input`` +
+``public_input_policy`` blocks: exactly six closed input kinds, a fail-closed
+admission layer that rejects every contract ``rejection_reason``, a snapshot
+identity whose identity-bearing subset excludes fetch-volatile fields, and
+replay durability (bytes MATERIALIZED, locator is provenance only). Identity is
+minted through :mod:`identity` (``input_record_id`` / ``input_set_id``) and never
+re-derived here.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from assetutilities.workflow_api import identity, inputs
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+
+def _dataset(**overrides) -> dict:
+    """A fully-admissible dataset_snapshot input (materialized + pinned + public)."""
+    kwargs = dict(
+        kind="dataset_snapshot",
+        role="wells",
+        schema_version="wed-1",
+        source_authority="EIA",
+        public_locator={"uri": "https://eia.gov/ds/wells", "version": "v2026-06"},
+        data_as_of="2026-06-01",
+        retrieval_time="2026-07-11T00:00:00Z",
+        selection={"basin": "permian"},
+        snapshot_identity="d" * 64,
+        content_digest="a" * 64,  # materialized HF object (via #3429)
+        redistribution_rights="public",
+        redistribution_evidence={"license": "CC-BY-4.0", "checked_at": "2026-07-11"},
+        replay_location="content_addressed_dataset_object",
+    )
+    kwargs.update(overrides)
+    return inputs.make_input(**kwargs)
+
+
+def _artifact_ref(**overrides) -> dict:
+    kwargs = dict(
+        kind="artifact_reference",
+        role="grid",
+        schema_version="grid-2",
+        content_digest="b" * 64,
+        redistribution_rights="public",
+        replay_location="content_addressed_dataset_object",
+    )
+    kwargs.update(overrides)
+    return inputs.make_input(**kwargs)
+
+
+def _config(**overrides) -> dict:
+    kwargs = dict(
+        kind="configuration_document",
+        role="run_config",
+        schema_version="cfg-1",
+        canonical_repr={"a": 1, "b": 5.0, "nested": {"x": 1, "y": 2}},
+        redistribution_rights="owned",
+        replay_location="content_addressed_dataset_object",
+    )
+    kwargs.update(overrides)
+    return inputs.make_input(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. six closed input kinds (api -> dataset_snapshot; unknown rejected)
+# ---------------------------------------------------------------------------
+
+def test_six_input_kinds_closed_enum():
+    assert inputs.INPUT_KINDS == frozenset({
+        "parameter_set",
+        "configuration_document",
+        "dataset_snapshot",
+        "public_external_resource",
+        "upstream_run_reference",
+        "artifact_reference",
+    })
+    # each of the six classifies to itself
+    for kind in inputs.INPUT_KINDS:
+        assert inputs.classify_kind(kind) == kind
+    # API-backed inputs are classified as dataset_snapshot (no separate `api` kind)
+    assert inputs.classify_kind("api") == "dataset_snapshot"
+    assert "api" not in inputs.INPUT_KINDS
+    # an unknown kind is rejected fail-closed
+    with pytest.raises(inputs.InputError):
+        inputs.classify_kind("database")
+    with pytest.raises(inputs.InputError):
+        inputs.make_input(kind="database", role="x", schema_version="s-1")
+
+
+# ---------------------------------------------------------------------------
+# 2. re-fetching the SAME snapshot yields the SAME input-set identity
+# ---------------------------------------------------------------------------
+
+def test_refetch_same_snapshot_yields_same_input_set_id():
+    a = _dataset(
+        retrieval_time="2026-07-11T00:00:00Z",
+        redistribution_evidence={"license": "CC-BY-4.0", "checked_at": "2026-07-11"},
+    )
+    # SAME snapshot re-fetched later: different retrieval_time AND different
+    # (volatile) redistribution_evidence -- neither is identity-bearing.
+    b = _dataset(
+        retrieval_time="2026-08-02T09:15:00Z",
+        redistribution_evidence={"license": "CC-BY-4.0", "checked_at": "2026-08-02",
+                                 "proof_url": "https://eia.gov/license"},
+    )
+    assert inputs.input_record_id(a) == inputs.input_record_id(b)
+    assert inputs.canonical_input_set_digest([a]) == inputs.canonical_input_set_digest([b])
+
+    # a genuine snapshot change (data_as_of / selection / snapshot_identity) DOES move it
+    assert inputs.input_record_id(_dataset(data_as_of="2026-05-01")) != inputs.input_record_id(a)
+    assert inputs.input_record_id(_dataset(selection={"basin": "eagleford"})) != inputs.input_record_id(a)
+    assert inputs.input_record_id(_dataset(snapshot_identity="e" * 64)) != inputs.input_record_id(a)
+
+
+# ---------------------------------------------------------------------------
+# 3. canonically-equivalent configs -> identical identity
+# ---------------------------------------------------------------------------
+
+def test_canonically_equivalent_configs_same_identity():
+    c1 = _config(canonical_repr={"a": 1, "b": 5.0, "nested": {"x": 1, "y": 2}})
+    # key order differs, whitespace irrelevant, numbers equivalent (5.00 == 5.0)
+    c2 = _config(canonical_repr={"b": Decimal("5.00"), "nested": {"y": 2, "x": 1}, "a": 1})
+    assert inputs.input_record_id(c1) == inputs.input_record_id(c2)
+    assert inputs.canonical_input_set_digest([c1]) == inputs.canonical_input_set_digest([c2])
+    # a real content change moves identity
+    assert inputs.input_record_id(_config(canonical_repr={"a": 2})) != inputs.input_record_id(c1)
+
+
+# ---------------------------------------------------------------------------
+# 4. ambiguous OR absent license fails admission
+# ---------------------------------------------------------------------------
+
+def test_ambiguous_or_unknown_license_fails_admission():
+    for rights in ("ambiguous", "unknown", None):
+        rec = _dataset(redistribution_rights=rights)
+        assert inputs.admission_reason(rec) == "ambiguous_license"
+        with pytest.raises(inputs.AdmissionError) as ei:
+            inputs.admit(rec)
+        assert ei.value.reason == "ambiguous_license"
+        with pytest.raises(inputs.AdmissionError):
+            inputs.input_record_id(rec)
+
+
+# ---------------------------------------------------------------------------
+# 5. admission rejects EVERY contract rejection_reason
+# ---------------------------------------------------------------------------
+
+def test_admission_rejects_all_contract_rejection_reasons():
+    cases = {
+        "restricted": _dataset(redistribution_rights="restricted"),
+        "private": _dataset(residency="private"),
+        "path_leaking": _dataset(public_locator={"uri": "/mnt/local/data.csv", "version": "v1"}),
+        "schema_invalid": _dataset(schema_version=None),
+        # pinned + hashed (snapshot_identity) but NOT materialized -> locator/pointer only
+        "pointer_only": _dataset(content_digest=None, canonical_repr=None),
+        # materialized but no snapshot pin (missing snapshot_identity)
+        "mutable_unpinned": _dataset(snapshot_identity=None),
+        # a reference input carrying no content hash at all
+        "unhashed": _artifact_ref(content_digest=None),
+        # valid+hashed+materialized reference but no complete_replay_location
+        "incomplete": _artifact_ref(replay_location=None),
+    }
+    for expected, rec in cases.items():
+        assert inputs.admission_reason(rec) == expected, expected
+        with pytest.raises(inputs.AdmissionError) as ei:
+            inputs.admit(rec)
+        assert ei.value.reason == expected, expected
+    # every reason exercised is a declared contract rejection reason
+    assert set(cases) | {"ambiguous_license"} <= inputs.REJECTION_REASONS
+
+
+# ---------------------------------------------------------------------------
+# 6. absolute local paths forbidden (path_leaking)
+# ---------------------------------------------------------------------------
+
+def test_absolute_local_path_forbidden():
+    for leak in ("/mnt/local/data.csv", "~/secret/data", "file:///etc/passwd",
+                 "C:\\\\data\\\\x.csv"):
+        rec = _dataset(public_locator={"uri": leak, "version": "v1"})
+        assert inputs.admission_reason(rec) == "path_leaking"
+    # a path leaking through an embedded config value is also caught
+    bad_cfg = _config(canonical_repr={"input_path": "/home/vamsee/data.csv"})
+    assert inputs.admission_reason(bad_cfg) == "path_leaking"
+    # a proper remote URL is NOT a path leak
+    assert inputs.admission_reason(_dataset()) is None
+
+
+# ---------------------------------------------------------------------------
+# 7. data_as_of == retrieval_time (utc_now) WITHOUT a snapshot identity fails
+# ---------------------------------------------------------------------------
+
+def test_data_as_of_run_timestamp_without_snapshot_identity_fails():
+    now = "2026-07-11T12:00:00Z"
+    # worldenergydata utc_now pattern: data_as_of stamped as the run/fetch time
+    volatile = _dataset(data_as_of=now, retrieval_time=now, snapshot_identity=None)
+    # the RULE is the missing snapshot identity (mutable_unpinned), not the
+    # timestamp equality which is only the SYMPTOM.
+    assert inputs.admission_reason(volatile) == "mutable_unpinned"
+    with pytest.raises(inputs.AdmissionError):
+        inputs.admit(volatile)
+    # pin it with a real byte-snapshot identity (timestamps still equal) -> admitted
+    pinned = _dataset(data_as_of=now, retrieval_time=now, snapshot_identity="f" * 64)
+    assert inputs.admission_reason(pinned) is None
+    inputs.admit(pinned)
+
+
+# ---------------------------------------------------------------------------
+# 8. schema-invalid input fails closed
+# ---------------------------------------------------------------------------
+
+def test_schema_invalid_input_fails_closed():
+    for bad in (None, "", 3):
+        rec = _dataset(schema_version=bad)
+        assert inputs.admission_reason(rec) == "schema_invalid"
+        with pytest.raises(inputs.AdmissionError):
+            inputs.input_record_id(rec)
+
+
+# ---------------------------------------------------------------------------
+# 9. replay-critical bytes MUST be materialized (locator is provenance only)
+# ---------------------------------------------------------------------------
+
+def test_replay_bytes_must_be_materialized():
+    # locator-only: a stable public URI with an immutable snapshot digest, but the
+    # bytes are NOT materialized (no content-addressed HF object, no embedded repr).
+    locator_only = _dataset(
+        content_digest=None, canonical_repr=None,
+        replay_location="stable_public_uri_with_immutable_digest",
+    )
+    assert inputs.admission_reason(locator_only) == "pointer_only"
+
+    # materialized as a content-addressed HF object -> admitted
+    materialized_obj = _dataset(content_digest="a" * 64)
+    assert inputs.admission_reason(materialized_obj) is None
+
+    # materialized by embedding the canonical representation -> admitted
+    embedded = _dataset(
+        content_digest=None,
+        canonical_repr={"rows": [{"well": "A"}, {"well": "B"}]},
+    )
+    assert inputs.admission_reason(embedded) is None
+
+
+# ---------------------------------------------------------------------------
+# 10. a parameter cannot be counted on BOTH input-set and execution-parameter sides
+# ---------------------------------------------------------------------------
+
+def test_parameter_not_double_counted_across_contracts():
+    params = inputs.make_input(
+        kind="parameter_set",
+        role="tuning",
+        schema_version="p-1",
+        canonical_repr={"tolerance": "1e-6", "max_iter": 100},
+        redistribution_rights="owned",
+        replay_location="content_addressed_dataset_object",
+    )
+    # disjoint sides are fine (execution_parameters are run-control knobs, #3428)
+    inputs.check_no_parameter_double_count([params], {"mode": "fast", "seed_source": "explicit"})
+    # the SAME key on both sides is rejected -- it belongs to exactly one contract
+    with pytest.raises(inputs.InputError):
+        inputs.check_no_parameter_double_count([params], {"tolerance": "1e-9"})
+
+
+# ---------------------------------------------------------------------------
+# 11. record + set identity are minted THROUGH the identity module
+# ---------------------------------------------------------------------------
+
+def test_input_record_and_set_reuse_identity_module():
+    rec = _dataset()
+    subset = inputs.snapshot_identity_subset(rec)
+    # identity-bearing subset is EXACTLY the five snapshot fields (fetch-volatile
+    # retrieval_time + redistribution_evidence excluded)
+    assert set(subset) == {
+        "source_authority", "public_locator", "data_as_of", "selection", "snapshot_identity",
+    }
+    expected_components = {
+        "role": "wells",
+        "native_schema_version": "wed-1",
+        "source_snapshot": identity.canonical_digest("input_source_snapshot", subset),
+        "transformation_id": "identity",
+        "artifact_sha256": "a" * 64,
+        "redistribution_rights": "public",
+        "complete_replay_location": "content_addressed_dataset_object",
+    }
+    assert inputs.input_record_id(rec) == identity.input_record_id(expected_components)
+
+    # the set digest is the identity module's input_set_id over (role, record_id) pairs
+    rec2 = _artifact_ref(role="grid")
+    pairs = [(rec["role"], inputs.input_record_id(rec)),
+             (rec2["role"], inputs.input_record_id(rec2))]
+    assert inputs.canonical_input_set_digest([rec, rec2]) == identity.input_set_id(pairs)
+    # order-independent (identity.input_set_id sorts)
+    assert (inputs.canonical_input_set_digest([rec, rec2])
+            == inputs.canonical_input_set_digest([rec2, rec]))


### PR DESCRIPTION
## workspace-hub #3430 — replayable public input + source snapshot contract

Reference implementation + TDD proof. Stacked on #3428 (PR #111) + #3429 (PR #112). Plan-approved (workspace-hub PR #3468).

**`workflow_api.inputs`** (stdlib-only; reuses identity + artifact):
- **Six closed input kinds** (api → dataset_snapshot); each replay-critical input binds schema_version, canonical repr, digest, role, required_for_replay.
- **`canonical_input_set_digest` excludes fetch-volatile fields**: `SNAPSHOT_IDENTITY_FIELDS = {source_authority, public_locator, data_as_of, selection, snapshot_identity}` — `retrieval_time` and `redistribution_evidence` are recorded but NOT in the digest, so re-fetching the same immutable snapshot yields the same run_id. (Stable rights *token* stays identity-bearing; volatile *evidence* excluded.)
- **Fail-closed admission** against the contract's exact `rejection_reasons` (restricted, pointer_only, ambiguous_license, mutable_unpinned, unhashed, schema_invalid, incomplete, private, path_leaking); absolute local paths forbidden. The operative pinned-snapshot rule = (`snapshot_identity` ∧ versioned `public_locator`); the `data_as_of==retrieval_time` (worldenergydata `utc_now`) case fails as `mutable_unpinned` (missing snapshot = rule, timestamp = symptom).
- **Replay bytes materialized** (HF-resident artifact or embedded canonical_repr); locator is provenance, not the reconstruction source. **parameter_set vs execution_parameters** double-count check (cross-plan with #3428).

**Tests:** 11 first-fail TDD tests → green; full `tests/workflow_api/` suite **59 passed**.

Refs workspace-hub#3430 workspace-hub#3427 · consumes #3428/#3429 · consumed by #3433.