### PR TITLE
fix: issue 80 residual security sweep - SQLi, process exits, bare excepts, credential leak

### DIFF
--- a/src/assetutilities/common/ApplicationManager.py
+++ b/src/assetutilities/common/ApplicationManager.py
@@ -265,10 +265,16 @@ class ConfigureApplicationInputs:
                 with open(self.customYaml) as fp:
                     custom_file_data = fp.read()
             except Exception as e:
+                # Library code must not kill the host process: engine() callers
+                # need to catch this, emit a summary carrying screening_status
+                # and record the failure in their provenance block. Raising
+                # preserves the original message and the cause (issue #80).
                 print("Update Input file could not be loaded successfully.")
                 print(f"Error is : {e}")
-                print("Stopping program")
-                sys.exit()
+                raise ValueError(
+                    f"Update Input file could not be loaded successfully: "
+                    f"{self.customYaml}"
+                ) from e
         elif self.CustomInputs is not None:
             custom_file_data = self.CustomInputs.replace("\\'", "'").replace(
                 "\\n", "\n"

--- a/src/assetutilities/common/ApplicationManager.py
+++ b/src/assetutilities/common/ApplicationManager.py
@@ -233,7 +233,8 @@ class ConfigureApplicationInputs:
                 self.customYaml = sys.argv[1]
             else:
                 self.customYaml = None
-        except:
+        except Exception as e:
+            logger.debug(f"Custom yaml could not be resolved from argv: {e}")
             self.customYaml = None
             if not is_pytest:
                 print(

--- a/src/assetutilities/common/database.py
+++ b/src/assetutilities/common/database.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 
 def get_db_connection(db_properties):
@@ -97,13 +98,36 @@ class Database:
         except Exception as e:
             print(f"Error getting input data in error {e}")
 
+    def _redact(self, message):
+        """Strip this connection's password out of arbitrary text.
+
+        Driver errors routinely embed the whole DSN, password included, so the
+        exception text is as much of a leak as printing the properties dict.
+        """
+        text = str(message)
+        if self.password:
+            text = text.replace(str(self.password), "***")
+        return text
+
+    def describe_connection(self):
+        """Non-secret identification of the configured connection.
+
+        Never includes password or connection_string (issue #80).
+        """
+        return (
+            f"server={self.server}, database={self.database}, user={self.user} "
+            "(credentials redacted)"
+        )
+
     def set_up_db_connection(self, db_properties):
         try:
             self.enable_connection_and_cursor()
             return True
         except Exception as e:
-            print(f"Error as {e}")
-            print(f"No connection for environment: {db_properties}")
+            # The previous implementation printed the whole db_properties dict,
+            # which carries `password` and `connection_string` (issue #80).
+            print(f"Error as {self._redact(e)}")
+            print(f"No connection for environment: {self.describe_connection()}")
             return False
 
     def enable_connection_and_cursor(self):
@@ -190,8 +214,9 @@ class Database:
                     f"Connection to Server: {self.server} Successful by user {self.user} to database {self.database}!"
                 )
 
-            except:
-                logging.info("MSSQL connection failed")
+            except Exception as e:
+                # Log the cause; it was discarded before (issue #80).
+                logging.info(f"MSSQL connection failed: {e}")
                 print("MSSQL connection failed")
 
         if self.server_type == "postgresql":
@@ -428,7 +453,7 @@ class Database:
             self.schema = db_table_df.iloc[row_index].TABLE_SCHEMA
             try:
                 column_df = self.get_table_columns(table_name)
-            except:
+            except Exception:
                 column_df = pd.DataFrame()
                 print(
                     f"          ..... FAILURE DB table columns for table {row_index} of {len(self.analysis.tables)}: {table_name}"
@@ -455,7 +480,7 @@ class Database:
                 self.get_table_statistics(table_name)
                 if len(self.table_statistics) > 0:
                     self.save_to_db(self.table_statistics, "TableStatistics")
-            except:
+            except Exception:
                 print(
                     f"          ..... FAILURE DB table statistics for table {table_index} of {len(self.analysis.tables)}: {table_name}"
                 )
@@ -743,52 +768,115 @@ class Database:
                         index_label=index_label,
                     )
 
-    def save_1_row_df_to_postgresql_db_using_primary_key(
-        self, df, cfg=None
-    ):
+    # A SQL identifier: a leading letter/underscore then letters, digits or
+    # underscores, optionally schema-qualified with a single dot. Deliberately
+    # strict -- identifiers cannot be passed as bound parameters, so the only
+    # safe handling is to reject anything that is not plainly an identifier.
+    SQL_IDENTIFIER_PATTERN = re.compile(
+        r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$"
+    )
+
+    @classmethod
+    def _validate_sql_identifier(cls, identifier, role):
+        if not isinstance(identifier, str) or not cls.SQL_IDENTIFIER_PATTERN.match(
+            identifier
+        ):
+            raise ValueError(
+                f"Invalid SQL identifier for {role}: {identifier!r}. "
+                "Identifiers cannot be parameterised, so only plain "
+                "(optionally schema-qualified) names are accepted."
+            )
+        return identifier
+
+    def build_upsert_statement(self, df, cfg):
+        """Build a parameterised single-row upsert.
+
+        Returns ``(statement_text, parameters)``. Values are always bound, never
+        interpolated, which closes the injection vector that the previous
+        ``sqlFileQuery.format(custom_dict=cfg)`` implementation carried (issue
+        #80). That implementation quoted values by string concatenation, so any
+        value containing an apostrophe broke or subverted the statement, and any
+        non-string value raised TypeError.
+
+        Identifiers (table, columns, primary key) cannot be bound, so they are
+        validated instead. Schema-qualified table names such as
+        ``stocks.analysis`` are accepted because real callers use them.
+
+        The statement is constructed here rather than read from
+        ``data/<server_type>/sql/common.upsert_single_record.sql``: that template
+        does not ship with this package, so the previous code path depended on a
+        file that had to exist in the caller's working directory.
+        """
+        if len(df) == 0:
+            raise ValueError("Cannot build an upsert statement from an empty dataframe")
+
+        table_name = self._validate_sql_identifier(
+            cfg.get("table_name", None), "table_name"
+        )
+        primary_key = self._validate_sql_identifier(
+            cfg.get("primary_key", None), "primary_key"
+        )
+
+        df_columns = [
+            self._validate_sql_identifier(column, "column") for column in df.columns
+        ]
+        if primary_key not in df_columns:
+            raise ValueError(
+                f"Primary key {primary_key!r} is not a column of the dataframe "
+                f"(columns: {df_columns})"
+            )
+
+        row = df.iloc[0].to_list()
+        placeholders = [f":v_{index}" for index in range(len(df_columns))]
+        parameters = {
+            f"v_{index}": self._as_bindable(value) for index, value in enumerate(row)
+        }
+
+        update_columns = [column for column in df_columns if column != primary_key]
+        set_code_block = ", ".join(
+            f"{column} = excluded.{column}" for column in update_columns
+        )
+
+        statement = (
+            f"INSERT INTO {table_name} ({', '.join(df_columns)}) "
+            f"VALUES ({', '.join(placeholders)}) "
+            f"ON CONFLICT ({primary_key}) DO UPDATE SET {set_code_block}"
+        )
+        return statement, parameters
+
+    @staticmethod
+    def _as_bindable(value):
+        """Convert a pandas scalar to something the DBAPI can bind.
+
+        numpy scalars are not accepted by every driver; ``item()`` unwraps them
+        to the equivalent Python builtin. NaN/NaT become None so they bind as
+        SQL NULL rather than the string 'nan'.
+        """
+        import pandas as pd
+
+        if value is None:
+            return None
+        if hasattr(value, "item") and getattr(value, "shape", None) == ():
+            value = value.item()
+        try:
+            if pd.isna(value):
+                return None
+        except (TypeError, ValueError):
+            pass
+        return value
+
+    def save_1_row_df_to_postgresql_db_using_primary_key(self, df, cfg=None):
         if cfg is None:
             cfg = {"table_name": None, "primary_key": None}
-        if len(df) > 0:
-            table_name = cfg.get("table_name", None)
-            cfg.update({"table_name": table_name})
+        if len(df) == 0:
+            # Nothing to write. The previous implementation fell through to a
+            # reference to `filename`, which was only assigned inside the
+            # non-empty branch, raising UnboundLocalError (issue #80).
+            logging.info("No row to upsert; dataframe is empty")
+            return
 
-            primary_key = cfg.get("primary_key", None)
-            cfg.update({"primary_key": primary_key})
-
-            df_columns = list(df.columns)
-            columns = ",".join(df_columns)
-            cfg.update({"columns": columns})
-
-            values = "({})".format(
-                ",".join(
-                    [
-                        "'" + item + "'" if item is not None else "NULL"
-                        for item in df.iloc[0].to_list()
-                    ]
-                )
-            )
-            cfg.update({"values": values})
-
-            df_columns.remove(primary_key)
-            set_code_block = "{}".format(
-                ",".join(
-                    [
-                        item + " = excluded." + item if item is not None else "NULL"
-                        for item in df_columns
-                    ]
-                )
-            )
-            cfg.update({"set_code_block": set_code_block})
-
-            filename = os.path.join(
-                "data", self.server_type, "sql", "common.upsert_single_record.sql"
-            )
-            sqlFileQuery = self.read_from_file(filename)
-            sqlFileQuery = sqlFileQuery.format(custom_dict=cfg)
-        if os.path.isfile(filename):
-            self.executeNoDataQuery(sqlFileQuery, [])
-        else:
-            print("Not a valid filename")
+        statement, parameters = self.build_upsert_statement(df, cfg)
+        self.executeNoDataQuery(statement, params=parameters)
 
     def get_table_column_statistics(self, table_name, column_name, column_data_type):
         import os
@@ -942,7 +1030,14 @@ class Database:
     def executeNoDataQuery_using_dict(self, query, dict):
         pass
 
-    def executeNoDataQuery(self, query, arg_array=None):
+    def executeNoDataQuery(self, query, arg_array=None, params=None):
+        """Execute a statement that returns no rows.
+
+        ``params`` carries bound parameters, which is how callers should pass
+        data values. ``arg_array`` is the legacy positional-format path, kept
+        for backward compatibility; it interpolates into the statement text and
+        so must only ever receive trusted identifiers, never user data.
+        """
         if arg_array is None:
             arg_array = []
         sql = query
@@ -959,12 +1054,18 @@ class Database:
                 arg_array[0], arg_array[1], arg_array[2], arg_array[3], arg_array[4]
             )
         try:
-            print(f"     .....Executing query: {sql}")
+            # Log only the leading verb, never the statement body: the previous
+            # print echoed every interpolated data value into stdout/logs
+            # (issue #80).
+            logging.debug(
+                f"     .....Executing no-data query: {sql.strip().split(None, 1)[0]}"
+            )
+            from sqlalchemy import text  # type: ignore
             from sqlalchemy.orm import scoped_session, sessionmaker  # type: ignore
 
             Session = scoped_session(sessionmaker(bind=self.engine))
             s = Session()
-            s.execute(query)
+            s.execute(text(sql), params or {})
             s.commit()
         except Exception as e:
             print("Command skipped: ", e)
@@ -1068,7 +1169,11 @@ class Database:
                                 statistics_df.StartTime
                                 == result_df.StartTime.iloc[row_index]
                             ][quantity_column_name].iloc[0]
-                        except:
+                        except Exception as e:
+                            logging.debug(
+                                f"Related quantity unavailable for row "
+                                f"{row_index}: {e}"
+                            )
                             related_quantity = None
                         temp_array.append(related_quantity)
                 else:

--- a/src/assetutilities/common/database.py
+++ b/src/assetutilities/common/database.py
@@ -834,14 +834,20 @@ class Database:
         }
 
         update_columns = [column for column in df_columns if column != primary_key]
-        set_code_block = ", ".join(
-            f"{column} = excluded.{column}" for column in update_columns
-        )
+        if update_columns:
+            set_code_block = ", ".join(
+                f"{column} = excluded.{column}" for column in update_columns
+            )
+            conflict_action = f"DO UPDATE SET {set_code_block}"
+        else:
+            # Nothing to update: the primary key is the only column. An empty
+            # SET list is a syntax error, so the correct action is DO NOTHING.
+            conflict_action = "DO NOTHING"
 
         statement = (
             f"INSERT INTO {table_name} ({', '.join(df_columns)}) "
             f"VALUES ({', '.join(placeholders)}) "
-            f"ON CONFLICT ({primary_key}) DO UPDATE SET {set_code_block}"
+            f"ON CONFLICT ({primary_key}) {conflict_action}"
         )
         return statement, parameters
 

--- a/src/assetutilities/common/database.py
+++ b/src/assetutilities/common/database.py
@@ -286,11 +286,11 @@ class Database:
                 self.conn = pypyodbc.connect(connection_string_generic)
 
             except Exception as e:
-                import sys
-
+                # Raise instead of exiting so callers can report the failure
+                # (issue #80). The print that used to sit after sys.exit() was
+                # unreachable dead code and has been removed.
                 logging.info(f"Access file connection failed: {e}")
-                sys.exit()
-                print("Access file connection failed")
+                raise ConnectionError(f"Access file connection failed: {e}") from e
 
     def perform_analysis(self, cfg_analysis):
         db_analysis_result = {}
@@ -1091,10 +1091,12 @@ class Database:
         if data_set_cfg.__contains__("x") and data_set_cfg.__contains__("y"):
             statistics_df_column_array = data_set_cfg["x"] + data_set_cfg["y"]
         else:
-            import sys
-
-            print("Data not defined for formatting table statstics")
-            sys.exit()
+            # Raise instead of exiting so the caller can report a misconfigured
+            # data set rather than losing the whole run (issue #80).
+            raise ValueError(
+                "Data not defined for formatting table statistics: "
+                "data_set_cfg must contain both 'x' and 'y'"
+            )
         statistics_df = pd.DataFrame()
         for column_index in range(0, len(statistics_df_column_array)):
             column_name = statistics_df_column_array[column_index]

--- a/src/assetutilities/common/database.py
+++ b/src/assetutilities/common/database.py
@@ -800,7 +800,8 @@ class Database:
 
         Identifiers (table, columns, primary key) cannot be bound, so they are
         validated instead. Schema-qualified table names such as
-        ``stocks.analysis`` are accepted because real callers use them.
+        ``stocks.analysis`` are accepted because that is the documented usage
+        shape; rejecting the dot would break it.
 
         The statement is constructed here rather than read from
         ``data/<server_type>/sql/common.upsert_single_record.sql``: that template

--- a/src/assetutilities/common/readers/data_reader.py
+++ b/src/assetutilities/common/readers/data_reader.py
@@ -247,7 +247,7 @@ class ReadData:
                 all_lines_float_objects.append(
                     [float(item) for item in line_string_objects]
                 )
-            except:
+            except Exception:
                 all_lines_float_objects.append(line_string_objects)
 
         result: list[list[Any]] = []

--- a/src/assetutilities/common/transform.py
+++ b/src/assetutilities/common/transform.py
@@ -30,7 +30,7 @@ class Transform:
                 latitude = float(df[latitude_column].iloc[df_row])
                 longitude = float(df[longitude_column].iloc[df_row])
                 x, y, zone, ut = utm.from_latlon(latitude, longitude)
-            except:
+            except Exception:
                 x, y, zone, ut = (None, None, None, None)
             x_array.append(x)
             y_array.append(y)
@@ -241,7 +241,7 @@ class Transform:
                         temp_df = pd.DataFrame.from_dict(
                             df.iloc[df_row][column], orient="columns"
                         )
-                    except:
+                    except Exception:
                         temp_df = pd.DataFrame.from_dict(
                             df.iloc[df_row][column], orient="index"
                         )

--- a/src/assetutilities/common/visualization.py
+++ b/src/assetutilities/common/visualization.py
@@ -167,8 +167,9 @@ class Visualization:
                     plot_data.append(data.copy())
 
             return plot_data
-        except:
-            logging.debug("Data does not exist")
+        except Exception as e:
+            # Include the cause; the message alone hid genuine errors (issue #80).
+            logging.debug(f"Data does not exist: {e}")
 
     def assign_grouped_data(self):
         try:
@@ -186,8 +187,8 @@ class Visualization:
                     text_data = grouped_df.get_group(name)[self.cfg["y"][0]]
                     data.update({"text": text_data})
                 self.plot_data["data"].append(data.copy())
-        except:
-            logging.debug("Data does not exist")
+        except Exception as e:
+            logging.debug(f"Data does not exist: {e}")
 
     def assign_custom_properties(self, cfg, sizedata, sizerefdata):
         cfg = self.get_cfg_with_custom_color(cfg, sizedata)

--- a/src/assetutilities/common/visualizations.py
+++ b/src/assetutilities/common/visualizations.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class Visualization:
     def __init__(self, plt_settings=None):
         # matplotlib.use('Agg')
@@ -338,7 +341,7 @@ class Visualization:
             file_name = self.plt_settings["file_name"]
             try:
                 self.plt.savefig(file_name, dpi=800)
-            except:
+            except Exception:
                 self.plt.savefig(file_name, dpi=100)
             self.plt.close()
             if self.polar_fig is not None:
@@ -411,14 +414,14 @@ class Visualization:
             ax = self.plot_object.axes()
             if max(ax.get_yticks().tolist()) < 0.001:
                 ax.set_yticklabels([f"{item:.1e}" for item in ax.get_yticks().tolist()])
-        except:
-            print("Axis not formatted")
+        except Exception as e:
+            print(f"Axis not formatted: {e}")
         try:
             ax = self.plot_object.axes()
             if max(ax.get_xticks().tolist()) < 0.001:
                 ax.set_xticklabels([f"{item:.1e}" for item in ax.get_xticks().tolist()])
-        except:
-            print("Axis not formatted")
+        except Exception as e:
+            print(f"Axis not formatted: {e}")
 
         if self.cfg_mult is None:
             self.plot_object.xlabel(
@@ -692,8 +695,10 @@ class Visualization:
             try:
                 self.plt_settings["ylim"] = cfg["RangeGraph"][RangeGraphIndex]["ylim"]
                 self.plt.ylim(self.plt_settings["ylim"])
-            except:
-                pass
+            except Exception as e:
+                # Optional setting; keep the no-op fallback but stop discarding
+                # the reason entirely (issue #80).
+                logging.debug(f"ylim not applied: {e}")
 
             self.plt.savefig(FileName, dpi=800)
             self.plt.close()

--- a/src/assetutilities/common/visualizations.py
+++ b/src/assetutilities/common/visualizations.py
@@ -167,13 +167,14 @@ class Visualization:
                     except Exception as e:
                         print(e)
                         if "datetime.date" in str(e):
-                            # Standard library imports
-                            import sys
-
-                            print(
-                                "Error: When using datetime as X-axis, consider changing plot kind from scatter to line "
-                            )
-                            sys.exit()
+                            # Raise instead of exiting so the caller keeps
+                            # control of the run (issue #80). Any other scatter
+                            # error is still swallowed, exactly as before - this
+                            # is a process-exit fix, not a handler redesign.
+                            raise ValueError(
+                                "When using datetime as X-axis, consider changing "
+                                "plot kind from scatter to line"
+                            ) from e
 
                 elif "polar" in plt_settings["plt_kind"]:
                     self.prepare_polar_plot(df, plt_settings, x, column_index, y, label)

--- a/src/assetutilities/common/writers.py
+++ b/src/assetutilities/common/writers.py
@@ -70,7 +70,7 @@ class SaveData:
 
         try:
             wb[data["SheetName"]]
-        except:
+        except Exception:
             wb.create_sheet(data["SheetName"])
             wb[data["SheetName"]]
 
@@ -91,12 +91,12 @@ class SaveData:
             wb = load_workbook(data["FileName"])
             writer = pd.ExcelWriter(data["FileName"], engine="openpyxl")
             writer.wb = wb
-        except:
+        except Exception:
             writer = pd.ExcelWriter(data["FileName"])
 
         try:
             wb[data["SheetName"]]
-        except:
+        except Exception:
             wb.create_sheet(data["SheetName"])
             wb[data["SheetName"]]
 

--- a/src/assetutilities/common/ymlInput.py
+++ b/src/assetutilities/common/ymlInput.py
@@ -15,10 +15,13 @@ def ymlInput(defaultYml, updateYml):
             #  Convert to logs
             # print(cfgUpdateValues)
             cfg = update_deep(cfg, cfgUpdateValues)
-        except:
+        except Exception as e:
+            # Surface the cause; this handler previously discarded it entirely
+            # (issue #80). Fallback behaviour is unchanged.
             print(
                 "Update Input file could not be loaded successfully. Running program default values"
             )
+            print(f"Error is : {e}")
 
     return cfg
 

--- a/src/assetutilities/common/yml_utilities.py
+++ b/src/assetutilities/common/yml_utilities.py
@@ -199,10 +199,13 @@ class WorkingWithYAML:
                 #  Convert to logs
                 # logger.info(cfgUpdateValues)
                 cfg = update_deep(cfg, cfgUpdateValues)  # type: ignore[assignment]
-            except:
+            except Exception as e:
+                # Surface the cause; this handler previously discarded it
+                # entirely (issue #80). Fallback behaviour is unchanged.
                 logger.info(
                     "Update Input file could not be loaded successfully. Running program default values"
                 )
+                logger.info(f"Error is : {e}")
 
         return cfg
 

--- a/tests/unit/test_database_retry_bound.py
+++ b/tests/unit/test_database_retry_bound.py
@@ -1,0 +1,93 @@
+# ABOUTME: Regression tests for the bounded db retry decorator (issue #80).
+# ABOUTME: The retry must terminate after a declared attempt budget, never recurse unbounded.
+
+import pytest
+
+try:
+    from assetutilities.common.database import Database
+except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
+    pytest.skip(
+        f"assetutilities.common optional dependency missing: {exc}",
+        allow_module_level=True,
+    )
+
+
+def _always_failing(budget):
+    """Build a class whose decorated method always raises, counting its calls.
+
+    The attempt budget is injected rather than hardcoded so the tests assert the
+    decorator honours the declared DB_RETRY_MAX_ATTEMPTS attribute, not some
+    constant baked into the decorator body.
+    """
+
+    class Probe:
+        DB_RETRY_MAX_ATTEMPTS = budget
+
+        def __init__(self):
+            self.calls = 0
+
+        @Database.db_retry_decorator
+        def operation(self):
+            self.calls += 1
+            raise RuntimeError("persistent failure")
+
+    return Probe()
+
+
+class TestRetryIsBounded:
+    def test_attempt_count_equals_declared_budget_of_two(self):
+        probe = _always_failing(2)
+        with pytest.raises(RuntimeError):
+            probe.operation()
+        assert probe.calls == 2
+
+    def test_attempt_count_equals_declared_budget_of_seven(self):
+        probe = _always_failing(7)
+        with pytest.raises(RuntimeError):
+            probe.operation()
+        assert probe.calls == 7
+
+    def test_persistent_failure_raises_the_original_error_not_recursionerror(self):
+        probe = _always_failing(3)
+        with pytest.raises(RuntimeError) as excinfo:
+            probe.operation()
+        assert str(excinfo.value) == "persistent failure"
+
+    def test_default_budget_is_a_finite_positive_integer(self):
+        # The value itself is a policy choice, not a derived quantity; what the
+        # security fix requires is that it exists and is finite.
+        assert Database.DB_RETRY_MAX_ATTEMPTS > 0
+
+
+class TestRetryStillSucceeds:
+    def test_operation_succeeding_on_second_attempt_returns_its_value(self):
+        class Probe:
+            DB_RETRY_MAX_ATTEMPTS = 5
+
+            def __init__(self):
+                self.calls = 0
+
+            @Database.db_retry_decorator
+            def operation(self):
+                self.calls += 1
+                if self.calls < 2:
+                    raise RuntimeError("transient failure")
+                return "settled"
+
+        assert Probe().operation() == "settled"
+
+    def test_operation_succeeding_immediately_is_called_exactly_once(self):
+        class Probe:
+            DB_RETRY_MAX_ATTEMPTS = 5
+
+            def __init__(self):
+                self.calls = 0
+
+            @Database.db_retry_decorator
+            def operation(self):
+                self.calls += 1
+                return "ok"
+
+        probe = Probe()
+        probe.operation()
+        assert probe.calls == 1

--- a/tests/unit/test_database_security.py
+++ b/tests/unit/test_database_security.py
@@ -206,9 +206,7 @@ class TestCredentialsAreNotLeaked:
             in capsys.readouterr().out
         )
 
-    def test_connection_failure_still_reports_false_to_the_caller(
-        self, monkeypatch
-    ):
+    def test_connection_failure_still_reports_false_to_the_caller(self, monkeypatch):
         db = make_db()
 
         def boom():
@@ -219,9 +217,7 @@ class TestCredentialsAreNotLeaked:
 
 
 class TestQueryLoggingDoesNotEchoValues:
-    def test_executenodataquery_does_not_print_the_interpolated_statement(
-        self, capsys
-    ):
+    def test_executenodataquery_does_not_print_the_interpolated_statement(self, capsys):
         db = make_db()  # no engine attribute -> the execute path fails immediately
         db.executeNoDataQuery(
             "INSERT INTO analysis (ticker) VALUES ('SENTINEL-PAYROLL-VALUE')"

--- a/tests/unit/test_database_security.py
+++ b/tests/unit/test_database_security.py
@@ -104,8 +104,12 @@ class TestUpsertIdentifiersAreValidated:
             )
 
     def test_schema_qualified_table_name_is_accepted(self):
-        # The one real downstream caller passes 'stocks.analysis'; a validator
-        # that rejected the dot would break a working path.
+        # Schema-qualified names must stay accepted: a validator that rejected
+        # the dot would break the documented usage shape. The equivalent
+        # function in a sibling repo is invoked with 'stocks.analysis'. That is
+        # a separate copy, not a caller of this one -- this module currently has
+        # no importer in the workspace -- so it is evidence about the intended
+        # config shape, not proof of a live call path.
         df = pd.DataFrame([{"ticker": "ACME", "company": "Acme"}])
         sql, _params = make_db().build_upsert_statement(
             df, {"table_name": "stocks.analysis", "primary_key": "ticker"}

--- a/tests/unit/test_database_security.py
+++ b/tests/unit/test_database_security.py
@@ -122,7 +122,14 @@ class TestUpsertRoundTripsThroughARealEngine:
 
     @pytest.fixture
     def sqlite_db(self):
-        from sqlalchemy import create_engine, text
+        # sqlalchemy is not a declared dependency of this project -- database.py
+        # imports it lazily inside functions -- so CI's test environment does not
+        # have it. Skip rather than error there; the statement-construction tests
+        # above still run everywhere and cover the injection vector itself.
+        sqlalchemy = pytest.importorskip(
+            "sqlalchemy", reason="sqlalchemy is not a declared project dependency"
+        )
+        create_engine, text = sqlalchemy.create_engine, sqlalchemy.text
 
         db = make_db()
         db.engine = create_engine("sqlite://")

--- a/tests/unit/test_database_security.py
+++ b/tests/unit/test_database_security.py
@@ -117,6 +117,24 @@ class TestUpsertIdentifiersAreValidated:
         assert sql.startswith("INSERT INTO stocks.analysis (")
 
 
+class TestUpsertWithNothingToUpdate:
+    """A dataframe whose only column is the primary key has no SET list.
+
+    Emitting 'DO UPDATE SET ' with an empty list is a syntax error, so the
+    correct statement for this shape is DO NOTHING.
+    """
+
+    def test_single_primary_key_column_produces_do_nothing(self):
+        df = pd.DataFrame([{"ticker": "ACME"}])
+        sql, _params = make_db().build_upsert_statement(
+            df, {"table_name": "analysis", "primary_key": "ticker"}
+        )
+        assert sql == (
+            "INSERT INTO analysis (ticker) VALUES (:v_0) "
+            "ON CONFLICT (ticker) DO NOTHING"
+        )
+
+
 class TestUpsertRoundTripsThroughARealEngine:
     """Legitimate input must still reach the database and land correctly."""
 
@@ -172,6 +190,22 @@ class TestUpsertRoundTripsThroughARealEngine:
             pd.DataFrame([{"ticker": "ACME", "company": "Acme Holdings"}]), cfg
         )
         assert self._fetch(sqlite_db, "ACME") == "Acme Holdings"
+
+    def test_primary_key_only_row_executes_without_a_syntax_error(self, sqlite_db):
+        from sqlalchemy import text
+
+        with sqlite_db.engine.begin() as conn:
+            conn.execute(text("CREATE TABLE keys (ticker TEXT PRIMARY KEY)"))
+        cfg = {"table_name": "keys", "primary_key": "ticker"}
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            pd.DataFrame([{"ticker": "ACME"}]), cfg
+        )
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            pd.DataFrame([{"ticker": "ACME"}]), cfg
+        )
+        with sqlite_db.engine.begin() as conn:
+            count = conn.execute(text("SELECT COUNT(*) FROM keys")).scalar()
+        assert count == 1
 
     def test_empty_dataframe_is_a_no_op_and_leaves_the_table_untouched(self, sqlite_db):
         from sqlalchemy import text

--- a/tests/unit/test_database_security.py
+++ b/tests/unit/test_database_security.py
@@ -1,0 +1,270 @@
+# ABOUTME: Security tests for common/database.py residuals in issue #80.
+# ABOUTME: Covers upsert SQL parameterisation, credential redaction and query-log hygiene.
+
+import pandas as pd
+import pytest
+
+try:
+    from assetutilities.common.database import Database
+except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
+    pytest.skip(
+        f"assetutilities.common optional dependency missing: {exc}",
+        allow_module_level=True,
+    )
+
+# Synthetic, non-secret. Only ever used to prove it never reaches stdout.
+FAKE_PASSWORD = "n0t-a-real-password-2f9c"
+
+
+def make_db():
+    return Database(
+        {
+            "server_type": "postgresql",
+            "server": "db.example.internal",
+            "database": "analytics",
+            "schema": "public",
+            "user": "svc_reader",
+            "password": FAKE_PASSWORD,
+            "port": 5432,
+        }
+    )
+
+
+class TestUpsertStatementIsParameterised:
+    """build_upsert_statement must bind values, never interpolate them."""
+
+    def _build(self, df, cfg=None):
+        cfg = cfg or {"table_name": "stocks.analysis", "primary_key": "ticker"}
+        return make_db().build_upsert_statement(df, cfg)
+
+    def test_statement_text_is_exactly_the_expected_parameterised_upsert(self):
+        df = pd.DataFrame([{"ticker": "ACME", "company": "Acme Corp"}])
+        sql, _params = self._build(df)
+        assert sql == (
+            "INSERT INTO stocks.analysis (ticker, company) "
+            "VALUES (:v_0, :v_1) "
+            "ON CONFLICT (ticker) DO UPDATE SET company = excluded.company"
+        )
+
+    def test_apostrophe_value_is_carried_in_the_bound_parameters(self):
+        df = pd.DataFrame([{"ticker": "OBR", "company": "O'Brien & Sons"}])
+        _sql, params = self._build(df)
+        assert params["v_1"] == "O'Brien & Sons"
+
+    def test_apostrophe_value_never_appears_in_the_statement_text(self):
+        df = pd.DataFrame([{"ticker": "OBR", "company": "O'Brien & Sons"}])
+        sql, _params = self._build(df)
+        assert "O'Brien" not in sql
+
+    def test_injection_payload_never_appears_in_the_statement_text(self):
+        payload = "x'); DROP TABLE stocks.analysis; --"
+        df = pd.DataFrame([{"ticker": "EVIL", "company": payload}])
+        sql, _params = self._build(df)
+        assert "DROP TABLE" not in sql
+
+    def test_numeric_value_is_bound_unchanged_instead_of_raising_typeerror(self):
+        df = pd.DataFrame([{"ticker": "ACME", "shares": 4200}])
+        _sql, params = self._build(
+            df, {"table_name": "stocks.analysis", "primary_key": "ticker"}
+        )
+        assert params["v_1"] == 4200
+
+    def test_none_value_is_bound_as_none(self):
+        df = pd.DataFrame([{"ticker": "ACME", "company": None}])
+        _sql, params = self._build(df)
+        assert params["v_1"] is None
+
+
+class TestUpsertIdentifiersAreValidated:
+    """Table/column names cannot be bound, so they must be validated instead."""
+
+    def test_table_name_carrying_a_statement_terminator_is_rejected(self):
+        df = pd.DataFrame([{"ticker": "ACME", "company": "Acme"}])
+        with pytest.raises(ValueError):
+            make_db().build_upsert_statement(
+                df,
+                {
+                    "table_name": "stocks.analysis; DROP TABLE stocks.keys",
+                    "primary_key": "ticker",
+                },
+            )
+
+    def test_column_name_carrying_a_statement_terminator_is_rejected(self):
+        df = pd.DataFrame([{"ticker": "ACME", "company); DROP TABLE t; --": "x"}])
+        with pytest.raises(ValueError):
+            make_db().build_upsert_statement(
+                df, {"table_name": "stocks.analysis", "primary_key": "ticker"}
+            )
+
+    def test_primary_key_absent_from_the_dataframe_is_rejected(self):
+        df = pd.DataFrame([{"ticker": "ACME", "company": "Acme"}])
+        with pytest.raises(ValueError):
+            make_db().build_upsert_statement(
+                df, {"table_name": "stocks.analysis", "primary_key": "isin"}
+            )
+
+    def test_schema_qualified_table_name_is_accepted(self):
+        # The one real downstream caller passes 'stocks.analysis'; a validator
+        # that rejected the dot would break a working path.
+        df = pd.DataFrame([{"ticker": "ACME", "company": "Acme"}])
+        sql, _params = make_db().build_upsert_statement(
+            df, {"table_name": "stocks.analysis", "primary_key": "ticker"}
+        )
+        assert sql.startswith("INSERT INTO stocks.analysis (")
+
+
+class TestUpsertRoundTripsThroughARealEngine:
+    """Legitimate input must still reach the database and land correctly."""
+
+    @pytest.fixture
+    def sqlite_db(self):
+        from sqlalchemy import create_engine, text
+
+        db = make_db()
+        db.engine = create_engine("sqlite://")
+        with db.engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE analysis (ticker TEXT PRIMARY KEY, company TEXT)")
+            )
+        return db
+
+    def _fetch(self, db, ticker):
+        from sqlalchemy import text
+
+        with db.engine.begin() as conn:
+            return conn.execute(
+                text("SELECT company FROM analysis WHERE ticker = :t"),
+                {"t": ticker},
+            ).scalar()
+
+    def test_apostrophe_value_round_trips_intact(self, sqlite_db):
+        df = pd.DataFrame([{"ticker": "OBR", "company": "O'Brien & Sons"}])
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            df, {"table_name": "analysis", "primary_key": "ticker"}
+        )
+        assert self._fetch(sqlite_db, "OBR") == "O'Brien & Sons"
+
+    def test_injection_payload_is_stored_as_data_not_executed(self, sqlite_db):
+        payload = "x'); DROP TABLE analysis; --"
+        df = pd.DataFrame([{"ticker": "EVIL", "company": payload}])
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            df, {"table_name": "analysis", "primary_key": "ticker"}
+        )
+        assert self._fetch(sqlite_db, "EVIL") == payload
+
+    def test_second_write_for_the_same_primary_key_updates_in_place(self, sqlite_db):
+        cfg = {"table_name": "analysis", "primary_key": "ticker"}
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            pd.DataFrame([{"ticker": "ACME", "company": "Acme Corp"}]), cfg
+        )
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            pd.DataFrame([{"ticker": "ACME", "company": "Acme Holdings"}]), cfg
+        )
+        assert self._fetch(sqlite_db, "ACME") == "Acme Holdings"
+
+    def test_empty_dataframe_is_a_no_op_and_leaves_the_table_untouched(self, sqlite_db):
+        from sqlalchemy import text
+
+        sqlite_db.save_1_row_df_to_postgresql_db_using_primary_key(
+            pd.DataFrame(columns=["ticker", "company"]),
+            {"table_name": "analysis", "primary_key": "ticker"},
+        )
+        with sqlite_db.engine.begin() as conn:
+            count = conn.execute(text("SELECT COUNT(*) FROM analysis")).scalar()
+        assert count == 0
+
+
+class TestCredentialsAreNotLeaked:
+    def test_connection_failure_output_does_not_contain_the_password(
+        self, monkeypatch, capsys
+    ):
+        db = make_db()
+
+        def boom():
+            # Mirrors a real driver error, which embeds the DSN.
+            raise RuntimeError(
+                f"could not connect: postgresql://svc_reader:{FAKE_PASSWORD}@db.example.internal:5432/analytics"
+            )
+
+        monkeypatch.setattr(db, "enable_connection_and_cursor", boom)
+        db.set_up_db_connection({"password": FAKE_PASSWORD})
+        assert FAKE_PASSWORD not in capsys.readouterr().out
+
+    def test_connection_failure_emits_the_redacted_environment_line(
+        self, monkeypatch, capsys
+    ):
+        db = make_db()
+
+        def boom():
+            raise RuntimeError("could not connect")
+
+        monkeypatch.setattr(db, "enable_connection_and_cursor", boom)
+        db.set_up_db_connection({"password": FAKE_PASSWORD})
+        assert (
+            "No connection for environment: server=db.example.internal, "
+            "database=analytics, user=svc_reader (credentials redacted)"
+            in capsys.readouterr().out
+        )
+
+    def test_connection_failure_still_reports_false_to_the_caller(
+        self, monkeypatch
+    ):
+        db = make_db()
+
+        def boom():
+            raise RuntimeError("could not connect")
+
+        monkeypatch.setattr(db, "enable_connection_and_cursor", boom)
+        assert db.set_up_db_connection({"password": FAKE_PASSWORD}) is False
+
+
+class TestQueryLoggingDoesNotEchoValues:
+    def test_executenodataquery_does_not_print_the_interpolated_statement(
+        self, capsys
+    ):
+        db = make_db()  # no engine attribute -> the execute path fails immediately
+        db.executeNoDataQuery(
+            "INSERT INTO analysis (ticker) VALUES ('SENTINEL-PAYROLL-VALUE')"
+        )
+        assert "SENTINEL-PAYROLL-VALUE" not in capsys.readouterr().out
+
+
+class TestFormatTableStatisticsRaisesInsteadOfExiting:
+    def test_missing_x_and_y_keys_raise_valueerror(self):
+        with pytest.raises(ValueError):
+            make_db().format_table_statistics_df(pd.DataFrame(), {"statistic": "mean"})
+
+    def test_missing_x_and_y_keys_carry_the_original_message(self):
+        with pytest.raises(ValueError) as excinfo:
+            make_db().format_table_statistics_df(pd.DataFrame(), {"statistic": "mean"})
+        assert str(excinfo.value) == (
+            "Data not defined for formatting table statistics: "
+            "data_set_cfg must contain both 'x' and 'y'"
+        )
+
+    def test_missing_x_and_y_keys_do_not_raise_systemexit(self):
+        # SystemExit is a BaseException, so it would slip past the ValueError
+        # check above; assert its absence explicitly.
+        try:
+            make_db().format_table_statistics_df(pd.DataFrame(), {"statistic": "mean"})
+        except SystemExit:  # pragma: no cover - the defect being fixed
+            raised_systemexit = True
+        except ValueError:
+            raised_systemexit = False
+        assert raised_systemexit is False
+
+    def test_present_x_and_y_keys_still_produce_a_dataframe(self):
+        temp_df = pd.DataFrame(
+            [
+                {
+                    "ColumnName": "pressure",
+                    "ColumnDataType": "float",
+                    "StartTime": "2026-01-01T00:00:00",
+                    "mean": "1.5",
+                }
+            ]
+        )
+        result = make_db().format_table_statistics_df(
+            temp_df, {"x": [], "y": ["pressure"], "statistic": "mean"}
+        )
+        assert result["pressure"].to_list() == [1.5]

--- a/tests/unit/test_library_error_handling.py
+++ b/tests/unit/test_library_error_handling.py
@@ -7,10 +7,7 @@ import pathlib
 import pytest
 
 COMMON_DIR = (
-    pathlib.Path(__file__).resolve().parents[2]
-    / "src"
-    / "assetutilities"
-    / "common"
+    pathlib.Path(__file__).resolve().parents[2] / "src" / "assetutilities" / "common"
 )
 
 
@@ -143,8 +140,6 @@ class TestScatterPlotErrorRaisesInsteadOfExiting:
     def test_working_scatter_plot_is_unaffected(self, monkeypatch):
         viz, df, settings = self._visualization_and_frame(monkeypatch)
         calls = []
-        monkeypatch.setattr(
-            viz.plot_object, "scatter", lambda *a, **k: calls.append(1)
-        )
+        monkeypatch.setattr(viz.plot_object, "scatter", lambda *a, **k: calls.append(1))
         viz.from_df_columns(df, settings)
         assert len(calls) == 1

--- a/tests/unit/test_library_error_handling.py
+++ b/tests/unit/test_library_error_handling.py
@@ -1,0 +1,150 @@
+# ABOUTME: Tests that assetutilities library code raises instead of exiting the process (issue #80).
+# ABOUTME: Also pins the absence of bare except clauses, which swallow SystemExit/KeyboardInterrupt.
+
+import ast
+import pathlib
+
+import pytest
+
+COMMON_DIR = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "src"
+    / "assetutilities"
+    / "common"
+)
+
+
+def _python_files():
+    return sorted(COMMON_DIR.rglob("*.py"))
+
+
+def _sites(predicate):
+    """Return 'relpath:lineno' for every AST node in common/ matching predicate."""
+    found = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if predicate(node):
+                found.append(f"{path.relative_to(COMMON_DIR)}:{node.lineno}")
+    return found
+
+
+def _is_bare_except(node):
+    return isinstance(node, ast.ExceptHandler) and node.type is None
+
+
+def _is_sys_exit_call(node):
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "exit"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "sys"
+    )
+
+
+class TestNoProcessExitInLibraryCode:
+    def test_common_package_contains_no_sys_exit_calls(self):
+        # Library code must raise so callers can build a summary/provenance
+        # block; only CLI entry points may terminate the process.
+        assert _sites(_is_sys_exit_call) == []
+
+
+class TestNoBareExceptInLibraryCode:
+    def test_common_package_contains_no_bare_except_clauses(self):
+        # A bare except also catches SystemExit and KeyboardInterrupt.
+        assert _sites(_is_bare_except) == []
+
+
+try:
+    from assetutilities.common.ApplicationManager import ConfigureApplicationInputs
+    from assetutilities.common.visualizations import Visualization
+except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
+    pytest.skip(
+        f"assetutilities.common optional dependency missing: {exc}",
+        allow_module_level=True,
+    )
+
+
+class TestGenerateYMLInputRaisesOnUnreadableCustomYaml:
+    def _manager(self, custom_yaml):
+        manager = ConfigureApplicationInputs.__new__(ConfigureApplicationInputs)
+        manager.ApplicationInputFile = "does-not-exist.yml"
+        manager.ApplicationInputFile_dict = {"basename": "probe"}
+        manager.customYaml = custom_yaml
+        manager.CustomInputs = None
+        return manager
+
+    def test_unreadable_custom_yaml_raises_valueerror(self, tmp_path):
+        missing = str(tmp_path / "absent.yml")
+        with pytest.raises(ValueError):
+            self._manager(missing).generateYMLInput({}, {})
+
+    def test_unreadable_custom_yaml_does_not_raise_systemexit(self, tmp_path):
+        missing = str(tmp_path / "absent.yml")
+        try:
+            self._manager(missing).generateYMLInput({}, {})
+        except SystemExit:  # pragma: no cover - the defect being fixed
+            raised_systemexit = True
+        except ValueError:
+            raised_systemexit = False
+        assert raised_systemexit is False
+
+    def test_readable_custom_yaml_still_merges_into_the_configuration(self, tmp_path):
+        custom = tmp_path / "custom.yml"
+        custom.write_text("basename: probe\nsettings:\n  dpi: 300\n")
+        cfg = self._manager(str(custom)).generateYMLInput({}, {})
+        assert cfg["settings"]["dpi"] == 300
+
+
+class TestScatterPlotErrorRaisesInsteadOfExiting:
+    def _visualization_and_frame(self, monkeypatch):
+        import matplotlib
+        import pandas as pd
+
+        matplotlib.use("Agg")
+        viz = Visualization()
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        settings = {
+            "x": ["a"],
+            "y": ["b"],
+            "label": ["series"],
+            "plt_kind": "scatter",
+        }
+        return viz, df, settings
+
+    def test_datetime_scatter_failure_raises_valueerror(self, monkeypatch):
+        viz, df, settings = self._visualization_and_frame(monkeypatch)
+
+        def boom(*args, **kwargs):
+            raise TypeError("float() argument must be a number, not datetime.date")
+
+        monkeypatch.setattr(viz.plot_object, "scatter", boom)
+        with pytest.raises(ValueError):
+            viz.from_df_columns(df, settings)
+
+    def test_datetime_scatter_failure_does_not_raise_systemexit(self, monkeypatch):
+        viz, df, settings = self._visualization_and_frame(monkeypatch)
+
+        def boom(*args, **kwargs):
+            raise TypeError("float() argument must be a number, not datetime.date")
+
+        monkeypatch.setattr(viz.plot_object, "scatter", boom)
+        try:
+            viz.from_df_columns(df, settings)
+        except SystemExit:  # pragma: no cover - the defect being fixed
+            raised_systemexit = True
+        except ValueError:
+            raised_systemexit = False
+        assert raised_systemexit is False
+
+    def test_working_scatter_plot_is_unaffected(self, monkeypatch):
+        viz, df, settings = self._visualization_and_frame(monkeypatch)
+        calls = []
+        monkeypatch.setattr(
+            viz.plot_object, "scatter", lambda *a, **k: calls.append(1)
+        )
+        viz.from_df_columns(df, settings)
+        assert len(calls) == 1

--- a/tests/unit/test_yaml_loading_security.py
+++ b/tests/unit/test_yaml_loading_security.py
@@ -1,0 +1,76 @@
+# ABOUTME: Regression tests for YAML loading in assetutilities (issue #80).
+# ABOUTME: Every config loader must use safe_load: python-tag payloads rejected, plain YAML still loads.
+
+import pytest
+import yaml
+
+try:
+    from assetutilities.common.readers.data_reader import ReadData
+    from assetutilities.common.ymlInput import ymlInput as plain_yml_input
+    from assetutilities.common.yml_utilities import WorkingWithYAML
+except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
+    pytest.skip(
+        f"assetutilities.common optional dependency missing: {exc}",
+        allow_module_level=True,
+    )
+
+
+# A payload that yaml.Loader / yaml.UnsafeLoader would happily instantiate and
+# which yaml.safe_load must refuse. os.system is the canonical RCE gadget.
+UNSAFE_YAML = "cmd: !!python/object/apply:os.system ['echo pwned']\n"
+
+# The legitimate counterpart: ordinary scalars/lists/maps that safe_load has
+# always supported. If a fix broke normal configs this would fail.
+LEGITIMATE_YAML = (
+    "basename: viz\n"
+    "settings:\n"
+    "  plt_kind: line\n"
+    "  dpi: 800\n"
+    "  flags: [true, false]\n"
+)
+
+LEGITIMATE_EXPECTED = {
+    "basename": "viz",
+    "settings": {"plt_kind": "line", "dpi": 800, "flags": [True, False]},
+}
+
+
+@pytest.fixture
+def unsafe_file(tmp_path):
+    p = tmp_path / "unsafe.yml"
+    p.write_text(UNSAFE_YAML)
+    return str(p)
+
+
+@pytest.fixture
+def legit_file(tmp_path):
+    p = tmp_path / "legit.yml"
+    p.write_text(LEGITIMATE_YAML)
+    return str(p)
+
+
+class TestWorkingWithYAMLymlInput:
+    def test_python_tag_payload_is_rejected(self, unsafe_file):
+        with pytest.raises(yaml.constructor.ConstructorError):
+            WorkingWithYAML().ymlInput(unsafe_file)
+
+    def test_legitimate_yaml_still_loads(self, legit_file):
+        assert WorkingWithYAML().ymlInput(legit_file) == LEGITIMATE_EXPECTED
+
+
+class TestCommonYmlInput:
+    def test_python_tag_payload_is_rejected(self, unsafe_file):
+        with pytest.raises(yaml.constructor.ConstructorError):
+            plain_yml_input(unsafe_file, None)
+
+    def test_legitimate_yaml_still_loads(self, legit_file):
+        assert plain_yml_input(legit_file, None) == LEGITIMATE_EXPECTED
+
+
+class TestDataReaderReadYmlFile:
+    def test_python_tag_payload_is_rejected(self, unsafe_file):
+        with pytest.raises(yaml.constructor.ConstructorError):
+            ReadData().read_yml_file({"io": unsafe_file})
+
+    def test_legitimate_yaml_still_loads(self, legit_file):
+        assert ReadData().read_yml_file({"io": legit_file}) == LEGITIMATE_EXPECTED

--- a/tests/unit/test_yaml_loading_security.py
+++ b/tests/unit/test_yaml_loading_security.py
@@ -22,11 +22,7 @@ UNSAFE_YAML = "cmd: !!python/object/apply:os.system ['echo pwned']\n"
 # The legitimate counterpart: ordinary scalars/lists/maps that safe_load has
 # always supported. If a fix broke normal configs this would fail.
 LEGITIMATE_YAML = (
-    "basename: viz\n"
-    "settings:\n"
-    "  plt_kind: line\n"
-    "  dpi: 800\n"
-    "  flags: [true, false]\n"
+    "basename: viz\nsettings:\n  plt_kind: line\n  dpi: 800\n  flags: [true, false]\n"
 )
 
 LEGITIMATE_EXPECTED = {


### PR DESCRIPTION
Closes [#80](https://github.com/vamseeachanta/assetutilities/issues/80) (residual sweep — implements the approved plan in that issue).

The Critical tier of the 2026-05-23 review was fixed by [#95](https://github.com/vamseeachanta/assetutilities/pull/95). This PR finishes the residuals and adds the regression coverage the already-fixed classes never had.

## Why this matters beyond the individual defects

Every registered workflow reaches `common/` through `engine.py`. Four `sys.exit()` calls in that path killed the host process before any caller could emit a summary, while 19 bare `except:` clauses swallowed the very errors a provenance block needs to report. Downstream repos import these modules directly and inherited both behaviours.

## What changed

| Defect class | Before | After |
|---|---|---|
| SQL injection | `sqlFileQuery.format(custom_dict=cfg)` over concat-quoted values | `build_upsert_statement` — bound parameters, validated identifiers |
| `sys.exit()` in library code | 4 sites | 0 — all raise, original messages preserved |
| Bare `except:` | 19 sites in `common/` | 0 |
| Credential leak | printed the whole `db_properties` dict | `describe_connection()`, password scrubbed from driver errors too |
| SQL echoed to logs | `print(f"...Executing query: {sql}")` | leading verb only, at debug |

**Two latent bugs fixed while rebuilding the upsert:** an empty dataframe fell through to a `filename` reference assigned only inside the non-empty branch (`UnboundLocalError`), and numpy scalars / `NaN` now normalise so they bind as Python equivalents and as `NULL`.

**The upsert no longer reads `data/<server_type>/sql/common.upsert_single_record.sql`.** That template does not ship with this package, so the old path depended on a file existing in the caller's working directory. No caller supplies a customised template. Related: `executeNoDataQuery` previously handed a raw string to `Session.execute`, which SQLAlchemy 2.0 rejects — it is now wrapped in `text()` with its parameters, so this path executes for the first time under 2.0.

## Semantic change for downstream callers

Four paths now **raise where they previously exited the process**: `ApplicationManager.generateYMLInput` (unreadable custom YAML → `ValueError`), `Database.enable_connection_and_cursor` (accdb failure → `ConnectionError`), `Database.format_table_statistics_df` (missing `x`/`y` → `ValueError`), and `Visualization.from_df_columns` (datetime-scatter → `ValueError`). Callers that relied on the process dying will now see an exception propagate. `sys.exit` in CLI entry points is untouched — exiting is correct there.

The bare-except sweep changed **no** fallback behaviour; errors that were discarded entirely are now logged at the level the surrounding code already used.

## Verification

Interpreter `/usr/bin/python3` 3.12.3 (pytest 9.0.2, SQLAlchemy 2.0.46). The repo `.venv` has no `sqlalchemy` and cannot exercise this module.

Full suite, branch point `87789d7` vs HEAD — **node-ID diff is empty**:

```
baseline: 6 failed, 1433 passed, 3 skipped, 1 xfailed, 2 errors
after:    6 failed, 1475 passed, 3 skipped, 1 xfailed, 2 errors
```

Same 6 failures and 2 errors, identical node IDs, all pre-existing on `main` (routing-contract x3, engine-dispatch pdf x2, a network-dependent fetch test, and 2 benchmark collection errors). Passed count rises by exactly 42 — the new tests, nothing else.

`ruff check` on the touched paths: **19 `E722` findings removed, zero new findings**. Every remaining finding is pre-existing on `main` (verified by running ruff against an `origin/main` worktree). Ruff's independent `E722` count of 19 matches the AST sweep exactly. `scripts/hygiene/check-source-hygiene.sh` passes.

Each defect class has both an unsafe-input-rejected test and a legitimate-input-still-works test — a security fix that breaks a working path is not a fix. The upsert additionally round-trips through a real SQLite engine, proving an apostrophe value and an injection payload are stored as *data* and that a repeat write for the same primary key updates in place.

## TDD sequence (verifiable from the log)

```
cf5b176  test: regression coverage for classes already fixed by #95   (green on arrival, labelled as such)
71f5750  test: RED - residual defects        20 failed/2 passed + 6 failed/2 passed, recorded in the commit body
30af5b5  fix: raise instead of sys.exit
7dc4154  fix: bare except -> except Exception
95566a3  fix(database): parameterise upsert, redact credentials, stop echoing SQL
599dadb  style: ruff-format the new test files
```

The 4 tests green in the RED commit are the deliberate legitimate-path controls.

## Two call-site checks the plan required

1. **`ast.literal_eval` vs `eval`** — one call site, reached only for the brace-delimited *legacy dictionary literal* format, result type-checked with `isinstance(..., dict)`. No call site needs expression evaluation.
2. **`safe_load` vs custom tags** — there *are* `!!python/object/...` tags in 7 repo YAML files. All are dumped result artefacts written by `yaml.dump`, plus one orphan fixture with zero referencing code. None is read back through a `safe_load` path.

## Deliberately out of scope

- `executeScriptsFromFile` keeps its documented trusted-caller warning; full parameterisation is blocked on external `.sql` templates outside this repo.
- `ymlInput.ymlInput` calls `update_deep`, which the module never imports — the bare except was hiding a `NameError` on every call with an update file. Behaviour is unchanged and the cause is now visible, but the missing import is not fixed here.
- The *dump* side still emits python tags (which is why those artefacts exist).

## Correction to an earlier claim in this description

An earlier revision said "the one real downstream caller passes `stocks.analysis`". That was overstated and is now corrected in the code and tests (commit `efc55bf`). Verified by grep across the workspace: **`assetutilities.common.database` has no importer anywhere outside this repo's own tests.** The sibling repo that uses `stocks.analysis` carries its own copy of this function and does not call this one. The design decision is unchanged — schema-qualified names must be accepted — only the justification is corrected.

A practical consequence: the upsert path has **no live caller**, so its exercise here is limited to the new SQLite round-trip tests. That is real coverage of the statement builder and the execution path, but it is not production traffic.

## CI status — three failures, all pre-existing, none from this branch

| Check | Cause | Evidence it is not mine |
|---|---|---|
| `Domain docs` | `src/assetutilities/workflow_api/` exists on `main` but is absent from `MODULE_STRUCTURE.md`, the operator map and the routing registry (added by #111–#116, docs never updated) | Reproduces at the branch point `87789d7` before any commit of mine; this branch touches none of those files |
| `Domain workflow_api` | tempdir-leak assertion, xdist race | Failed on one run and **passed on the next with no relevant code change**; 113/113 pass locally when run serially |
| `Domain modules-data_exploration` | `FileExistsError` on the `logs` directory under xdist | `ApplicationManager.py:356` (`os.mkdir`) and `set_logging.py:28` (`os.makedirs`) lack `exist_ok=True`, unlike the sibling result-folder calls fixed by #102. This branch touches neither line |

`main` looks green only because its push-triggered run executes a **changed-paths-scoped** subset — the run at `87789d7` had 4 jobs and never ran the docs domain at all. The routing contract is latently broken on `main`; this PR merely triggers the job that reveals it.

All three are outside the approved scope of [#80](https://github.com/vamseeachanta/assetutilities/issues/80), so they are reported rather than fixed here.

**Not merging this myself** — handing the merge to the owner.

